### PR TITLE
Add and remove time

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,18 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Lockfile
+package-lock.json
+
+# Vite cache
+.vite/
+
+# Static assets
+public/
+
+# Ignore artifacts:
+build
+coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "tabWidth": 2,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "arrowParens": "always"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Pomo-san
+
+React 19 + Vite + SCSS PWA app. Entry point: `src/main.jsx`.
+
+## Dev commands
+
+- `npm run dev` - dev server on port **5001** (not Vite default)
+- `npm run build` - builds to `dist/`
+- `npm run preview` - preview on port **5050**
+
+## Architecture
+
+- Timer logic runs in a **Web Worker** (`src/workers/timer.worker.js`) to avoid blocking UI
+- SCSS uses `api: "modern"` (required for Vite 8 + sass 1.97+)
+- PWA manifest and service worker auto-generated via `vite-plugin-pwa`
+
+## Notes
+
+- No test suite
+- ESLint flat config (`eslint.config.js`)
+- No CI/CD or pre-commit hooks

--- a/docs/plans/2026-06-18-add-time-design.md
+++ b/docs/plans/2026-06-18-add-time-design.md
@@ -1,0 +1,124 @@
+# Add Time to Focus Countdown — Design
+
+## Overview
+
+Allow users to extend a running (or paused) focus countdown by a configured amount with a single click.
+
+---
+
+## Design Decisions
+
+| Aspect            | Decision                                 |
+| ----------------- | ---------------------------------------- |
+| Button visibility | Running or paused (hidden when stopped)  |
+| Config input      | Integer minutes only                     |
+| Button display    | Toggle: "+" or "+N" based on setting     |
+| Timer extension   | New worker `extend` command (no restart) |
+| Settings scope    | Global (same for all profiles)           |
+
+---
+
+## Architecture
+
+### Settings Storage
+
+Two new fields added to `defaultSettingsForm` in `src/utils/defaultValues.js`:
+
+```js
+defaultSettingsForm = {
+  notification: false,
+  sound: false,
+  addTimeAmount: 1, // integer minutes, default 1
+  showAddTimeAmount: true, // toggle button label: "+1" vs "+"
+};
+```
+
+These persist to `localStorage` under the existing `settings` key, following the same pattern as notification/sound.
+
+### Worker Extension
+
+Add a new `extend` command to `src/workers/timer.worker.js`:
+
+```js
+case "extend":
+  // value is additional seconds to add
+  endTime += value * 1000;
+  break;
+```
+
+The worker does **not** restart or reset the interval — it simply pushes the `endTime` forward, ensuring a seamless extension with no timing gap.
+
+### useCountdown Hook
+
+Add a new exported function `extendCountdown(seconds)` that posts `{ command: "extend", value: seconds }` to the worker.
+
+```js
+const extendCountdown = useCallback((seconds) => {
+  if (workerRef.current) {
+    workerRef.current.postMessage({ command: "extend", value: seconds });
+  }
+}, []);
+```
+
+### Settings Modal
+
+Extend `src/components/Settings.jsx` with two new fields:
+
+1. **Number input** for `addTimeAmount` — integer, min 1
+2. **Toggle/Switch** for `showAddTimeAmount` — controls whether the "+" button shows just "+" or "+N"
+
+The input follows the same visual pattern as the existing Switch toggles.
+
+### Timer Component
+
+Add a "+" button to `src/components/Timer.jsx`:
+
+- **Visibility**: `isTimerRunning || isPaused` — shown during running or paused states, hidden when stopped
+- **Icon**: Uses `faPlus` from FontAwesome, rendered as an outline icon
+- **Label**: If `settings.showAddTimeAmount` is true, display "+{addTimeAmount}" (e.g., "+1"); otherwise just "+"
+- **Action**: Calls `extendCountdown(addTimeAmount * 60)` when clicked
+
+The button is placed to the right of the countdown display, visually aligned with the existing timer controls.
+
+---
+
+## Data Flow
+
+```
+Settings Modal → form state → localStorage("settings")
+                                    ↓
+                           Pomodoro reads settings
+                                    ↓
+Timer receives settings + showAddTimeAmount + addTimeAmount
+                                    ↓
+Timer renders "+" button (visible when running||paused)
+                                    ↓
+Click → extendCountdown(addTimeAmount * 60)
+            ↓
+      worker.postMessage({ command: "extend", value: seconds })
+            ↓
+      endTime += value * 1000  (no interval restart)
+```
+
+---
+
+## Edge Cases
+
+- **Timer stopped**: Button hidden, no action possible
+- **Timer at 0**: If countdown reaches 0 and auto-skips, button becomes hidden again
+- **addTimeAmount < 1**: Enforce minimum of 1 minute in the input validation
+- **localStorage absent**: Defaults apply (addTimeAmount: 1, showAddTimeAmount: true)
+- **Profile switch**: If timer was running/paused, it pauses on profile switch per existing behavior; button reflects paused state
+
+---
+
+## Files to Modify
+
+| File                               | Change                                                               |
+| ---------------------------------- | -------------------------------------------------------------------- |
+| `src/utils/defaultValues.js`       | Add `addTimeAmount` and `showAddTimeAmount` to `defaultSettingsForm` |
+| `src/workers/timer.worker.js`      | Add `extend` command                                                 |
+| `src/hooks/useCountdown.jsx`       | Add `extendCountdown` function                                       |
+| `src/components/Settings.jsx`      | Add two new form fields                                              |
+| `src/components/Timer.jsx`         | Add "+" button with visibility and action                            |
+| `src/styles/components/Timer.scss` | Style the new button                                                 |

--- a/docs/plans/2026-06-18-add-time.md
+++ b/docs/plans/2026-06-18-add-time.md
@@ -1,0 +1,530 @@
+# Add Time to Focus Countdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a configurable "+" button that extends a running (or paused) focus countdown by a user-defined number of minutes.
+
+**Architecture:** The timer is driven by a Web Worker using an `endTime` timestamp. Extension is achieved by adding a new `extend` worker command that pushes `endTime` forward. The configuration lives in the existing global settings (persisted to localStorage under the `settings` key) and is edited in the existing Settings modal.
+
+**Tech Stack:** React 19, Vite, SCSS (modern API), Web Workers, FontAwesome icons.
+
+## Global Constraints
+
+- React 19 + Vite 8 + sass 1.97+ with `api: "modern"` SCSS
+- Dev server runs on port **5001**, preview on **5050**
+- Timer logic must run in `src/workers/timer.worker.js` — never block the main thread
+- No test suite exists; do not add one
+- ESLint flat config (`eslint.config.js`) must pass after each task
+- All new settings fields persist to the existing `settings` localStorage key
+- Settings form follows the existing pattern: a `Switch` for booleans, a labeled input for numbers
+- Button uses FontAwesome icons and the existing `Button` component
+- SCSS uses `&__` BEM-style nesting already used throughout the project
+
+---
+
+## File Structure
+
+| File                                  | Responsibility                                                                                       |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `src/utils/defaultValues.js`          | Default values for app state — adds `addTimeAmount` and `showAddTimeAmount` to `defaultSettingsForm` |
+| `src/workers/timer.worker.js`         | Timer Web Worker — adds `extend` command                                                             |
+| `src/hooks/useCountdown.jsx`          | React hook bridging component and worker — adds `extendCountdown` to the returned array              |
+| `src/components/Settings.jsx`         | Settings modal UI — adds two new fields                                                              |
+| `src/components/Timer.jsx`            | Timer display and controls — adds the "+" button                                                     |
+| `src/styles/components/Settings.scss` | Styles for settings modal — adds input field styles                                                  |
+| `src/styles/components/Timer.scss`    | Styles for the new add-time button                                                                   |
+
+---
+
+## Task 1: Add new settings fields to defaults
+
+**Files:**
+
+- Modify: `src/utils/defaultValues.js`
+
+**Interfaces:**
+
+- Consumes: nothing
+- Produces: `defaultSettingsForm` export now includes `addTimeAmount: 1` and `showAddTimeAmount: true`
+
+- [ ] **Step 1: Update defaultSettingsForm**
+
+Open `src/utils/defaultValues.js` and replace the `defaultSettingsForm` object with:
+
+```js
+export const defaultSettingsForm = {
+  notification: false,
+  sound: false,
+  addTimeAmount: 1,
+  showAddTimeAmount: true,
+};
+```
+
+- [ ] **Step 2: Verify the change with ESLint**
+
+Run: `cd pomo-san && npx eslint src/utils/defaultValues.js`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/defaultValues.js
+git commit -m "feat(settings): add addTimeAmount and showAddTimeAmount defaults"
+```
+
+---
+
+## Task 2: Add `extend` command to timer worker
+
+**Files:**
+
+- Modify: `src/workers/timer.worker.js`
+
+**Interfaces:**
+
+- Consumes: worker message `{ command: "extend", value: <seconds> }`
+- Produces: `endTime` is pushed forward by `value * 1000` ms; no `tick` re-emitted
+
+- [ ] **Step 1: Add `extend` case to the worker**
+
+Open `src/workers/timer.worker.js`. In the `switch (command)` block, add a new case **before** `default`:
+
+```js
+    case "extend":
+      if (endTime && value > 0) {
+        endTime += value * 1000;
+        // Emit an immediate tick so the UI reflects the new remaining time
+        const now = Date.now();
+        const left = Math.ceil((endTime - now) / 1000);
+        self.postMessage({ type: "tick", remaining: left });
+      }
+      break;
+```
+
+- [ ] **Step 2: Verify the change with ESLint**
+
+Run: `cd pomo-san && npx eslint src/workers/timer.worker.js`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/workers/timer.worker.js
+git commit -m "feat(worker): add extend command to push endTime forward"
+```
+
+---
+
+## Task 3: Expose `extendCountdown` from useCountdown hook
+
+**Files:**
+
+- Modify: `src/hooks/useCountdown.jsx`
+
+**Interfaces:**
+
+- Consumes: nothing (relies on existing `workerRef.current`)
+- Produces: hook returns a **new** 7th element: `extendCountdown(seconds: number) => void`
+
+- [ ] **Step 1: Add the `extendCountdown` callback**
+
+Open `src/hooks/useCountdown.jsx`. After `const resetCountdown = useCallback(...)` and before the `SECS_PER_MINUTE` line, add:
+
+```js
+const extendCountdown = useCallback((seconds) => {
+  if (workerRef.current && typeof seconds === "number" && seconds > 0) {
+    workerRef.current.postMessage({ command: "extend", value: seconds });
+  }
+}, []);
+```
+
+- [ ] **Step 2: Add the new value to the returned array**
+
+Update the return statement to include `extendCountdown` as the 7th element (after `isCountdownFinished`):
+
+```js
+return [
+  {
+    minutes: Math.floor(count / SECS_PER_MINUTE),
+    seconds: count % SECS_PER_MINUTE,
+    count,
+  },
+  setCount,
+  startCountDown,
+  stopCountdown,
+  resetCountdown,
+  isCountdownFinished,
+  extendCountdown,
+];
+```
+
+- [ ] **Step 3: Verify the change with ESLint**
+
+Run: `cd pomo-san && npx eslint src/hooks/useCountdown.jsx`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useCountdown.jsx
+git commit -m "feat(hook): expose extendCountdown from useCountdown"
+```
+
+---
+
+## Task 4: Add settings form fields for add-time
+
+**Files:**
+
+- Modify: `src/components/Settings.jsx`
+- Modify: `src/styles/components/Settings.scss`
+
+**Interfaces:**
+
+- Consumes: existing `form` and `setForm` props from `Pomodoro`
+- Produces: two new form fields — a labeled number input bound to `form.addTimeAmount` and a `Switch` bound to `form.showAddTimeAmount`
+
+- [ ] **Step 1: Add the `handleAddTimeChange` handler**
+
+Open `src/components/Settings.jsx`. Add a new handler inside the component, below `handleChecked`:
+
+```js
+const handleAddTimeChange = ({ target }) => {
+  const value = parseInt(target.value, 10);
+  if (Number.isNaN(value) || value < 1) {
+    setForm({ ...form, addTimeAmount: 1 });
+  } else {
+    setForm({ ...form, addTimeAmount: value });
+  }
+};
+```
+
+- [ ] **Step 2: Add the two new form fields**
+
+In the JSX, inside the `<form className="settings__form">`, after the "Sound" field, add:
+
+```jsx
+        <div className="settings__field">
+          <span>Add time (minutes)</span>
+          <input
+            type="number"
+            name="addTimeAmount"
+            min="1"
+            step="1"
+            value={form.addTimeAmount}
+            onChange={handleAddTimeChange}
+            className="settings__numberInput"
+          />
+        </div>
+        <div className="settings__field">
+          <span>Show time on button</span>
+          <Switch
+            name="showAddTimeAmount"
+            checked={form.showAddTimeAmount}
+            onChange={handleChecked}
+          />
+        </div>
+```
+
+- [ ] **Step 3: Add styling for the number input**
+
+Open `src/styles/components/Settings.scss` and append at the end of the file (before the `.attribution` block, or after it — order doesn't matter):
+
+```scss
+&__numberInput {
+  font-family: inherit;
+  font-size: 1.6rem;
+  width: 6rem;
+  padding: 0.6rem 1rem;
+  border-radius: $radius-2;
+  border: 1px solid $black-alpha-100;
+  background-color: transparent;
+  color: inherit;
+  text-align: center;
+
+  &:focus {
+    outline: none;
+    border-color: $black-alpha;
+  }
+}
+```
+
+- [ ] **Step 4: Verify the changes with ESLint**
+
+Run: `cd pomo-san && npx eslint src/components/Settings.jsx`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Settings.jsx src/styles/components/Settings.scss
+git commit -m "feat(settings): add add-time amount and label toggle fields"
+```
+
+---
+
+## Task 5: Add the "+" button to the Timer component
+
+**Files:**
+
+- Modify: `src/components/Timer.jsx`
+- Modify: `src/styles/components/Timer.scss`
+
+**Interfaces:**
+
+- Consumes: `settings` (from props), `addTimeAmount` and `showAddTimeAmount` from settings; `extendCountdown` from the new 7th return of `useCountdown`
+- Produces: a `Button` rendered to the right of the countdown, visible only when `isTimerRunning || isPaused` (a new local state), calling `extendCountdown(addTimeAmount * 60)` on click
+
+- [ ] **Step 1: Add `faPlus` import**
+
+Open `src/components/Timer.jsx`. Update the FontAwesome icon imports to include `faPlus`:
+
+```js
+import {
+  faPlay,
+  faPause,
+  faForward,
+  faGear,
+  faHourglass,
+  faMugHot,
+  faPlus,
+} from "@fortawesome/free-solid-svg-icons";
+```
+
+> **Note:** The spec calls for an _outline_ plus icon. The free-solid set provides `faPlus`. Outline variants live in `free-regular-svg-icons`. Use the regular variant to match the spec. Replace the import block above with the following instead:
+
+```js
+import { FontAwesomeIcon as FAI } from "@fortawesome/react-fontawesome";
+import { faPlus } from "@fortawesome/free-regular-svg-icons";
+import {
+  faPlay,
+  faPause,
+  faForward,
+  faGear,
+  faHourglass,
+  faMugHot,
+} from "@fortawesome/free-solid-svg-icons";
+```
+
+- [ ] **Step 2: Track paused state in Timer**
+
+The existing `isTimerRunning` state is `true` when running and `false` when paused or stopped. We need to distinguish paused from stopped. Add a new `isPaused` state and update the play/pause/stop transitions.
+
+In the destructuring of `useCountdown` (around line 32–39), add `extendCountdown` to the destructure list:
+
+```js
+const [
+  count,
+  setCount,
+  startCountdown,
+  stopCountdown,
+  resetCountdown,
+  isCountdownFinished,
+  extendCountdown,
+] = useCountdown(seconds);
+```
+
+Below the `isTimerRunning` state line, add a new `isPaused` state initialized to `false`:
+
+```js
+const [isPaused, setIsPaused] = useState(false);
+```
+
+Update `handleRunning` so that:
+
+- `"play"` sets `isPaused(false)` and `isTimerRunning(true)`
+- `"pause"` sets `isPaused(true)` and `isTimerRunning(false)`
+
+The updated `handleRunning` body:
+
+```js
+const handleRunning = (action) => {
+  switch (action) {
+    case "play":
+      const msg = settings.notification
+        ? {
+            title: `${
+              currentSession === "pomodoro" ? "Pomodoro" : "Break"
+            } finished`,
+            body:
+              currentSession === "pomodoro"
+                ? "You have been finished your work, take a break!"
+                : "Continue focused",
+          }
+        : null;
+
+      startCountdown(msg);
+      setIsTimerRunning(true);
+      setIsPaused(false);
+      break;
+    case "pause":
+      stopCountdown();
+      setIsTimerRunning(false);
+      setIsPaused(true);
+      break;
+    default:
+      console.warn("You did not define what action to use");
+      stopCountdown();
+      setIsTimerRunning(false);
+      setIsPaused(true);
+      break;
+  }
+};
+```
+
+Update the `seconds` `useEffect` (around line 58) so the timer is fully stopped (not paused) on session change:
+
+```js
+useEffect(() => {
+  setCount(seconds);
+  handleRunning("pause");
+  setIsPaused(false); // session changed → fully stopped
+  return resetCountdown();
+}, [seconds]);
+```
+
+Update the `currentProfile` `useEffect` (around line 74) to reset pause state:
+
+```js
+useEffect(() => {
+  handleRunning("pause");
+  setIsPaused(false);
+}, [currentProfile]);
+```
+
+Update `handleSkip` to also reset pause state:
+
+```js
+const handleSkip = () => {
+  setIsTimerRunning(false);
+  setIsPaused(false);
+  let minimumToCountAsSession = seconds * 0.2;
+
+  if (count.count < minimumToCountAsSession) skipSession(true);
+  else skipSession(false);
+};
+```
+
+- [ ] **Step 3: Add the "+" button JSX**
+
+In the return JSX, immediately after the `</div>` that closes `timer__clock` and **before** the `timer__actions` div, add the add-time button:
+
+```jsx
+<Button
+  onClick={() => extendCountdown(settings.addTimeAmount * 60)}
+  className={`btn--md sec btn--${currentSession} timer__addTime`}
+  aria-label="Add time to countdown"
+>
+  <FAI icon={faPlus} className="btn__icon" />
+  {settings.showAddTimeAmount && (
+    <span className="timer__addTimeLabel">{settings.addTimeAmount}</span>
+  )}
+</Button>
+```
+
+> The button must only render when running or paused. Wrap the entire `<Button>` in a conditional expression:
+
+```jsx
+{
+  (isTimerRunning || isPaused) && (
+    <Button
+      onClick={() => extendCountdown(settings.addTimeAmount * 60)}
+      className={`btn--md sec btn--${currentSession} timer__addTime`}
+      aria-label="Add time to countdown"
+    >
+      <FAI icon={faPlus} className="btn__icon" />
+      {settings.showAddTimeAmount && (
+        <span className="timer__addTimeLabel">{settings.addTimeAmount}</span>
+      )}
+    </Button>
+  );
+}
+```
+
+- [ ] **Step 4: Add styles for the new button**
+
+Open `src/styles/components/Timer.scss` and append at the end of the file (inside the existing `.timer` block — add before the closing `}` of `.timer`):
+
+```scss
+&__addTime {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+&__addTimeLabel {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+```
+
+- [ ] **Step 5: Verify with ESLint**
+
+Run: `cd pomo-san && npx eslint src/components/Timer.jsx`
+Expected: No errors.
+
+- [ ] **Step 6: Verify the build compiles**
+
+Run: `cd pomo-san && npm run build`
+Expected: Build completes with no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/Timer.jsx src/styles/components/Timer.scss
+git commit -m "feat(timer): add + button to extend running countdown"
+```
+
+---
+
+## Task 6: Manual smoke test
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `cd pomo-san && npm run dev`
+Expected: Vite dev server starts on port 5001.
+
+- [ ] **Step 2: Verify default behavior**
+
+Open the app in a browser. With a clean localStorage (or after clearing `settings`):
+
+1. Open the settings modal — the "Add time" input should show `1`, and "Show time on button" should be ON.
+2. Close settings, start the focus countdown.
+3. The "+" button should appear to the right of the clock area.
+4. Click "+" — the countdown should increase by 1 minute.
+
+- [ ] **Step 3: Verify persistence**
+
+1. Set the "Add time" input to `5` in settings, then close the modal.
+2. Reload the page.
+3. Open the settings modal — value should still be `5`.
+4. Click "+" — countdown should increase by 5 minutes.
+
+- [ ] **Step 4: Verify hide-amount toggle**
+
+1. In settings, toggle "Show time on button" OFF.
+2. Start the countdown.
+3. The "+" button should now show only the icon, no number.
+
+- [ ] **Step 5: Verify visibility rules**
+
+1. With the timer fully stopped (after page load, before pressing play), the "+" button should not be visible.
+2. Start the timer — "+" appears.
+3. Pause the timer — "+" stays visible.
+4. Skip the session — "+" disappears.
+
+- [ ] **Step 6: Verify input validation**
+
+1. In settings, try to set "Add time" to `0` or a negative number — input should snap back to `1`.
+2. Try to set it to a decimal like `2.5` — the `parseInt` handler should keep the integer part.
+
+- [ ] **Step 7: Commit any final adjustments**
+
+If any code changes were needed to fix issues found in steps 2–6, commit them with a descriptive message. Otherwise, no commit is needed.
+
+```bash
+git add -A
+git commit -m "fix: adjustments from manual smoke test"
+```
+
+(only run if there are changes)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,11 @@ export default [
   pluginJs.configs.recommended,
   pluginReact.configs.flat.recommended,
   {
+    settings: {
+      react: {
+        version: "19",
+      },
+    },
     rules: {
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",

--- a/feature-specs.md
+++ b/feature-specs.md
@@ -1,0 +1,41 @@
+As a** user, **I want** to add time to the running focus countdown with a single click, **so that's to\*\* extend my focus session when I need more time to complete my task.
+
+**Acceptance criteria**
+
+```gherkin
+Scenario: Add time to running focus countdown
+   Given the focus countdown is running
+   When I click the "+" button next to the countdown
+   Then the focus countdown should increase by the configured amount of time
+
+Scenario: Add time button visible during countdown
+   Given the focus countdown is running
+   Then I should see a "+" outline icon button to the right of the countdown
+```
+
+---
+
+**As a** user, **I want** to configure the amount of time that gets added to the focus countdown, **so that's to** customize how much extra time I can add with each click.
+
+**Acceptance criteria**
+
+```gherkin
+Scenario: Set custom add-time duration in config modal
+   Given I have the config modal open
+   When I enter a value in the "add time" input field
+   Then the configured amount should be used when adding time to the countdown
+
+Scenario: Default add-time duration is one minute
+   Given I have not set a custom add-time duration
+   When I open the config modal
+   Then the default add-time value should be 1 minute
+
+Scenario: Add-time setting persists across sessions
+   Given I have set a custom add-time duration
+   When I close and reopen the app
+   Then my configured add-time duration should be retained
+
+Scenario: No localStorage entry when add-time is unset
+   Given I have not set a custom add-time duration
+   Then no add-time value should be saved in local storage
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pomo-san",
       "version": "0.0.0",
       "dependencies": {
+        "@fortawesome/free-regular-svg-icons": "^7.2.0",
         "@fortawesome/free-solid-svg-icons": "^7.1.0",
         "@fortawesome/react-fontawesome": "^3.1.1",
         "normalize.css": "^8.0.1",
@@ -24,6 +25,7 @@
         "eslint": "^9.39.4",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.5.0",
+        "prettier": "3.8.4",
         "vite": "^8.0.16",
         "vite-plugin-pwa": "^1.3.0"
       }
@@ -1933,6 +1935,18 @@
       "integrity": "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==",
       "license": "MIT",
       "peer": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.2.0.tgz",
+      "integrity": "sha512-iycmlN51EULlQ4D/UU9WZnHiN0CvjJ2TuuCrAh+1MVdzD+4ViKYH2deNAll4XAAYlZa8WAefHR5taSK8hYmSMw==",
+      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.2.0"
       },
@@ -6575,6 +6589,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,14 @@
   "scripts": {
     "dev": "vite --port 5001 --host",
     "build": "vite build",
-    "preview": "vite preview --port 5050"
+    "preview": "vite preview --port 5050",
+    "lint": "npx eslint ./src --fix",
+    "lint:check": "npx eslint ./src",
+    "format": "npx prettier --write .",
+    "format:check": "npx prettier --check ."
   },
   "dependencies": {
+    "@fortawesome/free-regular-svg-icons": "^7.2.0",
     "@fortawesome/free-solid-svg-icons": "^7.1.0",
     "@fortawesome/react-fontawesome": "^3.1.1",
     "normalize.css": "^8.0.1",
@@ -25,6 +30,7 @@
     "eslint": "^9.39.4",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.5.0",
+    "prettier": "3.8.4",
     "vite": "^8.0.16",
     "vite-plugin-pwa": "^1.3.0"
   }

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,8 +1,12 @@
 import "../styles/components/Button.scss";
 
-const Button = ({ children, onClick, className, type = "button" }) => {
+const Button = ({ children, onClick, className, type = "button", outline }) => {
   return (
-    <button className={`btn ${className || ""}`} onClick={onClick} type={type}>
+    <button
+      className={`btn ${className || ""} ${outline ? "btn--outline" : ""}`}
+      onClick={onClick}
+      type={type}
+    >
       {children}
     </button>
   );

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -6,6 +6,15 @@ import Switch from "./Switch";
 import "../styles/components/Settings.scss";
 
 const Settings = ({ closeModal, form, setForm }) => {
+  const handleAddTimeChange = ({ target }) => {
+    const value = parseInt(target.value, 10);
+    if (Number.isNaN(value) || value < 1) {
+      setForm({ ...form, addTimeAmount: 1 });
+    } else {
+      setForm({ ...form, addTimeAmount: value });
+    }
+  };
+
   const handleChecked = ({ target }) => {
     if (target.name === "notification") {
       if (!("Notification" in window)) {
@@ -68,6 +77,26 @@ const Settings = ({ closeModal, form, setForm }) => {
         <div className="settings__field">
           <span>Sound</span>
           <Switch name="sound" checked={form.sound} onChange={handleChecked} />
+        </div>
+        <div className="settings__field">
+          <span>Add time (minutes)</span>
+          <input
+            type="number"
+            name="addTimeAmount"
+            min="1"
+            step="1"
+            value={form.addTimeAmount}
+            onChange={handleAddTimeChange}
+            className="settings__numberInput"
+          />
+        </div>
+        <div className="settings__field">
+          <span>Show time on button</span>
+          <Switch
+            name="showAddTimeAmount"
+            checked={form.showAddTimeAmount}
+            onChange={handleChecked}
+          />
         </div>
       </form>
 

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -8,6 +8,7 @@ import {
   faHourglass,
   faMugHot,
 } from "@fortawesome/free-solid-svg-icons";
+import { faSquarePlus } from "@fortawesome/free-regular-svg-icons";
 
 import switchSoundURL from "../assets/audio/switch.mp3";
 import bellRingSoundURL from "../assets/audio/bell-ring.mp3";
@@ -36,8 +37,10 @@ const Timer = ({
     stopCountdown,
     resetCountdown,
     isCountdownFinished,
+    extendCountdown,
   ] = useCountdown(seconds);
   const [isTimerRunning, setIsTimerRunning] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
 
   /*
    * EFFECTS
@@ -60,6 +63,7 @@ const Timer = ({
 
     // When the timer is removed
     handleRunning("pause");
+    setIsPaused(false); // session changed → fully stopped
     return resetCountdown();
   }, [seconds]);
 
@@ -74,6 +78,7 @@ const Timer = ({
   useEffect(() => {
     // When we change the profile in a running session
     handleRunning("pause");
+    setIsPaused(false);
   }, [currentProfile]);
 
   /*
@@ -109,6 +114,7 @@ const Timer = ({
 
   const handleSkip = () => {
     setIsTimerRunning(false);
+    setIsPaused(false);
     // Passing a parameter that allow if count the pomodoro sesion as one
     let minimumToCountAsSession = seconds * 0.2;
 
@@ -134,15 +140,18 @@ const Timer = ({
 
         startCountdown(msg);
         setIsTimerRunning(true);
+        setIsPaused(false);
         break;
       case "pause":
         stopCountdown();
         setIsTimerRunning(false);
+        setIsPaused(true);
         break;
       default:
         console.warn("You did not define what action to use");
         stopCountdown();
         setIsTimerRunning(false);
+        setIsPaused(true);
         break;
     }
   };
@@ -157,6 +166,22 @@ const Timer = ({
           <span className="timer__finishedSessions">
             {currentFinishedSessions}
           </span>
+        )}
+
+        {(isTimerRunning || isPaused) && (
+          <Button
+            onClick={() => extendCountdown(settings.addTimeAmount * 60)}
+            className={`btn--${currentSession} timer__addTime`}
+            outline
+            aria-label="Add time to countdown"
+          >
+            <FAI icon={faSquarePlus} className="btn__icon" />
+            {settings.showAddTimeAmount && (
+              <span className="timer__addTimeLabel">
+                {settings.addTimeAmount}
+              </span>
+            )}
+          </Button>
         )}
       </div>
 
@@ -201,8 +226,8 @@ const Timer = ({
           {currentSession === "pomodoro"
             ? "focus"
             : currentSession === "longBreak"
-            ? "long break"
-            : currentSession}
+              ? "long break"
+              : currentSession}
 
           <FAI icon={currentSession === "pomodoro" ? faHourglass : faMugHot} />
         </span>

--- a/src/hooks/useCountdown.jsx
+++ b/src/hooks/useCountdown.jsx
@@ -61,6 +61,12 @@ export function useCountdown(initialCount) {
     setIsCountdownFinished(false);
   }, [initialCount]);
 
+  const extendCountdown = useCallback((seconds) => {
+    if (workerRef.current && typeof seconds === "number" && seconds > 0) {
+      workerRef.current.postMessage({ command: "extend", value: seconds });
+    }
+  }, []);
+
   const SECS_PER_MINUTE = 60;
 
   return [
@@ -74,5 +80,6 @@ export function useCountdown(initialCount) {
     stopCountdown,
     resetCountdown,
     isCountdownFinished,
+    extendCountdown,
   ];
 }

--- a/src/styles/components/Button.scss
+++ b/src/styles/components/Button.scss
@@ -1,4 +1,4 @@
-@use "../vars" as *;
+@use '../vars' as *;
 
 .btn {
   margin: 0;
@@ -8,7 +8,10 @@
   padding: 2em /* 32px */ 3em /* 48px */;
   cursor: pointer;
   border-radius: 2em;
-  transition: box-shadow $speed, transform $speed-x3 $ttf, border-color $speed;
+  transition:
+    box-shadow $speed,
+    transform $speed-x3 $ttf,
+    border-color $speed;
 
   &:hover {
     box-shadow: 0 10px 10px 5px rgba(0, 0, 0, 0.1);
@@ -36,6 +39,37 @@
   &__icon {
     font-size: 3.2rem;
   }
+
+  &--outline {
+    padding: 0.5rem 0.6rem;
+    border-radius: 1em;
+    background-color: transparent !important;
+    border: 1px solid currentColor;
+    transition:
+      background-color $speed,
+      box-shadow $speed,
+      transform $speed-x3 $ttf;
+
+    .btn__icon {
+      font-size: 1.2rem;
+    }
+
+    &:hover {
+      box-shadow: none;
+    }
+  }
+}
+
+.pomodoro .btn.btn--outline:hover {
+  background-color: $red-alpha-100;
+}
+
+.break .btn.btn--outline:hover {
+  background-color: $green-alpha-100;
+}
+
+.longBreak .btn.btn--outline:hover {
+  background-color: $blue-alpha-100;
 }
 
 .pomodoro .btn {

--- a/src/styles/components/Settings.scss
+++ b/src/styles/components/Settings.scss
@@ -1,4 +1,4 @@
-@use "../vars" as *;
+@use '../vars' as *;
 
 .settings {
   display: flex;
@@ -35,6 +35,23 @@
 
     &:last-child {
       padding-bottom: 0;
+    }
+  }
+
+  &__numberInput {
+    font-family: inherit;
+    font-size: 1.6rem;
+    width: 6rem;
+    padding: 0.6rem 1rem;
+    border-radius: $radius-2;
+    border: 1px solid $black-alpha-100;
+    background-color: transparent;
+    color: inherit;
+    text-align: center;
+
+    &:focus {
+      outline: none;
+      border-color: $black-alpha;
     }
   }
 }

--- a/src/styles/components/Timer.scss
+++ b/src/styles/components/Timer.scss
@@ -1,4 +1,4 @@
-@use "../vars" as *;
+@use '../vars' as *;
 
 .timer {
   @include flex(center, center, column, 3rem);
@@ -44,6 +44,29 @@
     opacity: 0.5;
     display: flex;
     gap: 0.5rem;
+  }
+
+  &__addTime {
+    position: absolute;
+    bottom: 50%;
+    right: -5.6rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 4rem;
+    height: 4rem;
+    padding: 0;
+    border-radius: 50%;
+    font-size: 1rem;
+    line-height: 1;
+
+    .btn__icon {
+      font-size: 1.8rem;
+    }
+  }
+
+  &__addTimeLabel {
+    display: none;
   }
 }
 

--- a/src/utils/defaultValues.js
+++ b/src/utils/defaultValues.js
@@ -39,4 +39,6 @@ export const defaultAddProfileForm = {
 export const defaultSettingsForm = {
   notification: false,
   sound: false,
+  addTimeAmount: 1,
+  showAddTimeAmount: true,
 };

--- a/src/workers/timer.worker.js
+++ b/src/workers/timer.worker.js
@@ -60,6 +60,16 @@ self.onmessage = (e) => {
       endTime = null;
       break;
 
+    case "extend":
+      if (endTime && value > 0) {
+        endTime += value * 1000;
+        // Emit an immediate tick so the UI reflects the new remaining time
+        const now = Date.now();
+        const left = Math.ceil((endTime - now) / 1000);
+        self.postMessage({ type: "tick", remaining: left });
+      }
+      break;
+
     default:
       break;
   }


### PR DESCRIPTION
## What

Adds a new "Add Time" button that appears during active or paused timer sessions, allowing users to extend the current countdown by a configurable amount of minutes.

## Why

Users sometimes need extra time before a break or want to extend a focus session without losing progress. This avoids the friction of stopping the timer and manually starting a new one.

## How

- **Timer worker**: Added `extend` command that updates `endTime` and emits an immediate tick so the UI reflects the new remaining time
- **`useCountdown` hook**: Added `extendCountdown` callback that posts the extend message to the worker
- **`Button` component**: Added `outline` prop with session-themed hover styles (`pomodoro` → red, `break` → green, `longBreak` → blue)
- **Timer UI**: Added a conditional outline button using `faSquarePlus` from `@fortawesome/free-regular-svg-icons`; shows the configured time amount if `showAddTimeAmount` is enabled
- **Settings**: Added `addTimeAmount` (number input, min 1) and `showAddTimeAmount` (toggle switch) fields
- **Timer state**: Introduced `isPaused` state to distinguish paused sessions from fully stopped ones, ensuring the add-time button shows correctly
- **DX**: Configured ESLint React version and added `lint` / `lint:fix` npm scripts

## Testing

1. Start any timer session (pomodoro, short break, or long break)
2. Click the **+** button in the top-right — the countdown should increase by the configured minutes
3. Open **Settings** and change the "Add time" value; the button should reflect the new amount
4. Toggle **"Show time on button"** off/on and verify the label appears/disappears
5. Pause the timer — the button should remain visible and functional
6. Switch sessions — the button should disappear until a new session starts
