### PR TITLE
Feat/change main icons library

### DIFF
--- a/docs/plans/2026-06-22-fontawesome-to-lucide-design.md
+++ b/docs/plans/2026-06-22-fontawesome-to-lucide-design.md
@@ -1,0 +1,121 @@
+# Replace FontAwesome icons with Lucide React icons — Design
+
+Date: 2026-06-22
+Status: Approved (pending spec review)
+
+## Goal
+
+Replace all FontAwesome icon usages in the React source with [lucide-react](https://lucide.dev/) icons, then remove the FontAwesome dependencies. The visual outcome is a single, consistent stroke-icon set throughout the app.
+
+## Non-goals
+
+- Editing historical plan files in `docs/plans/` that mention FontAwesome (they document past decisions).
+- Manually editing `package-lock.json` (it regenerates via `npm install`).
+- Changing any SCSS rules or the `Button` component's `outline` prop.
+- Changing layout, aria labels, or component composition beyond the icon swap.
+
+## Current state
+
+FontAwesome is used in 5 source files with these icons:
+
+| File | FontAwesome icons |
+|---|---|
+| `src/components/Timer.jsx` | `faPlay`, `faPause`, `faForward`, `faGear`, `faHourglass`, `faMugHot` (solid); `faSquarePlus` (regular) |
+| `src/components/Settings.jsx` | `faXmark`, `faGear` |
+| `src/components/AddProfile.jsx` | `faCirclePlus`, `faEdit` |
+| `src/components/ProfileItem.jsx` | `faFeather`, `faTrash`, `faXmark` |
+| `src/components/ProfileSwitcher.jsx` | `faClock`, `faXmark`, `faCirclePlus` |
+
+`package.json` depends on:
+- `@fortawesome/free-regular-svg-icons` ^7.2.0
+- `@fortawesome/free-solid-svg-icons` ^7.1.0
+- `@fortawesome/react-fontawesome` ^3.1.1
+
+## Design
+
+### Dependency change
+
+- Add `lucide-react` (latest stable, React 19 compatible) to `dependencies`.
+- Remove all three `@fortawesome/*` entries from `package.json`.
+- Run `npm install` so the lockfile updates and `node_modules/@fortawesome/*` is cleared.
+
+### Import / usage pattern
+
+FontAwesome:
+```jsx
+import { FontAwesomeIcon as FAI } from "@fortawesome/react-fontawesome";
+import { faGear } from "@fortawesome/free-solid-svg-icons";
+<FAI icon={faGear} className="btn__icon" />
+```
+
+Lucide:
+```jsx
+import { Cog } from "lucide-react";
+<Cog className="btn__icon" />
+```
+
+Lucide components accept standard SVG/HTML attributes (`className`, `aria-*`, `style`) directly, so no wrapper component is needed. The existing `className="btn__icon"` is preserved, keeping SCSS sizing rules intact.
+
+### Icon mapping (closest-by-shape, unified stroke)
+
+Decision: match by visual meaning and accept Lucide's stroke-only aesthetic everywhere. FontAwesome's filled-solid look cannot be replicated; the point of the switch is a single consistent stroke set.
+
+| FontAwesome | Lucide | Reason |
+|---|---|---|
+| `faPlay` | `Play` | Triangle |
+| `faPause` | `Pause` | Two bars |
+| `faForward` | `FastForward` | Double-triangle skip |
+| `faGear` | `Cog` | Plain gear; `Settings` adds sliders, not wanted |
+| `faHourglass` | `Hourglass` | Same shape |
+| `faMugHot` | `Coffee` | Match by concept |
+| `faSquarePlus` (regular) | `SquarePlus` | Same outline shape |
+| `faXmark` | `X` | ✕ |
+| `faCirclePlus` | `CirclePlus` | Stroke replaces fill (per option A) |
+| `faEdit` | `Pencil` | Closest pencil shape |
+| `faFeather` | `Feather` | Same glyph exists |
+| `faTrash` | `Trash2` | Has the lid line like FA |
+| `faClock` | `Clock` | Same shape |
+
+### Dynamic icon choices
+
+Two spots pass a dynamic value to the `icon` prop. Lucide has no `icon` prop, so these become conditional JSX.
+
+`src/components/AddProfile.jsx` (current):
+```jsx
+<FontAwesomeIcon icon={btnName ? faEdit : faCirclePlus} />
+```
+becomes:
+```jsx
+{btnName ? <Pencil /> : <CirclePlus />}
+```
+
+`src/components/Timer.jsx` (current):
+```jsx
+<FAI icon={currentSession === "pomodoro" ? faHourglass : faMugHot} />
+```
+becomes:
+```jsx
+{currentSession === "pomodoro" ? <Hourglass /> : <Coffee />}
+```
+
+### Files touched
+
+- `package.json`
+- `src/components/Timer.jsx`
+- `src/components/Settings.jsx`
+- `src/components/AddProfile.jsx`
+- `src/components/ProfileItem.jsx`
+- `src/components/ProfileSwitcher.jsx`
+
+### Untouched
+
+- `docs/plans/*.md` files that mention FontAwesome — historical plans, out of scope.
+- `package-lock.json` — regenerates on `npm install`.
+- All SCSS — `btn__icon` selectors target the rendered SVG and do not reference FontAwesome's internal structure. During implementation, confirm no `*.fa-*` selectors exist anywhere in the styles; if any are found, flag them to the user rather than silently editing.
+- `Button` component's `outline` prop (`Timer.jsx` L174) — Button styling, not icon-related.
+
+## Validation
+
+- `npm run lint` passes on the 5 edited files (eslint flat config).
+- `npm run build` succeeds — no missing imports, no orphan `FAI` / `faX` references.
+- Visual confirmation is left to the user via `npm run preview` (no long-running dev server started by the agent).

--- a/docs/plans/2026-06-22-fontawesome-to-lucide.md
+++ b/docs/plans/2026-06-22-fontawesome-to-lucide.md
@@ -1,0 +1,770 @@
+# Replace FontAwesome with Lucide React — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace every FontAwesome icon in the React source with the equivalent `lucide-react` icon and remove the FontAwesome dependencies.
+
+**Architecture:** A pure icon-swap migration. Each `<FontAwesomeIcon icon={faX} />` is replaced by the corresponding Lucide component (`<X />`) passing the same `className`. Two dynamic-`icon` sites become conditional JSX because Lucide has no `icon` prop. The dependency change is staged: Lucide is added first, files are migrated one-by-one while keeping the app buildable, then FontAwesome packages are removed last.
+
+**Tech Stack:** React 19, Vite 8, SCSS (modern API), no test suite. Validation is ESLint (flat config) + `vite build`.
+
+## Global Constraints
+
+- Project root: `pomo-san/`. All paths in this plan are relative to the project root (`pomo-san/...`); run commands from the `pomo-san/` directory.
+- Dev/build commands (from `pomo-san/AGENTS.md`):
+  - `npm run dev` — dev server on port **5001**
+  - `npm run build` — builds to `dist/`
+  - `npm run preview` — preview on port **5050**
+- No test suite exists in this project (`pomo-san/AGENTS.md`). Per-task verification uses ESLint on the edited file and, for the final task, a full `npm run build`.
+- Exact ESLint invocation per file: `npx eslint <path>` (the `lint:check` script targets the whole `src/` tree; this plan scopes to one file per task for fast feedback).
+- ESLint flat config at `eslint.config.js` enables `react/react-in-jsx-scope: off` and `react/prop-types: off` — no changes to those rules are needed for Lucide imports.
+- Lucide components accept standard SVG/HTML attributes (`className`, `aria-*`, `style`) directly. No wrapper component is introduced.
+- Icon mapping (decided in the approved spec `docs/plans/2026-06-22-fontawesome-to-lucide-design.md`):
+
+  | FontAwesome | Lucide |
+  |---|---|
+  | `faPlay` | `Play` |
+  | `faPause` | `Pause` |
+  | `faForward` | `FastForward` |
+  | `faGear` | `Cog` |
+  | `faHourglass` | `Hourglass` |
+  | `faMugHot` | `Coffee` |
+  | `faSquarePlus` (regular) | `SquarePlus` |
+  | `faXmark` | `X` |
+  | `faCirclePlus` | `CirclePlus` |
+  | `faEdit` | `Pencil` |
+  | `faFeather` | `Feather` |
+  | `faTrash` | `Trash2` |
+  | `faClock` | `Clock` |
+
+- Out of scope (per spec): editing `docs/plans/*.md` files that mention FontAwesome, manually editing `package-lock.json` (regenerates on `npm install`), changing any SCSS, changing the `Button` component's `outline` prop. An SCSS grep in Task 7 confirms no `*.fa-*` selectors are left behind — if any are found, flag to the user rather than editing.
+
+## File Structure
+
+Files modified (no new files created):
+
+- `pomo-san/package.json` — drop 3 `@fortawesome/*` deps, add `lucide-react`. (Touched in Task 1 and Task 7.)
+- `pomo-san/src/components/Settings.jsx` — 2 icons.
+- `pomo-san/src/components/AddProfile.jsx` — 2 icons, 1 dynamic-`icon` site.
+- `pomo-san/src/components/ProfileItem.jsx` — 3 icons.
+- `pomo-san/src/components/ProfileSwitcher.jsx` — 3 icons (4 usage sites).
+- `pomo-san/src/components/Timer.jsx` — 7 icons, 1 dynamic-`icon` site.
+
+No SCSS files are modified.
+
+---
+
+### Task 1: Add `lucide-react` dependency
+
+**Files:**
+- Modify: `pomo-san/package.json` (dependencies block)
+
+**Interfaces:**
+- Produces: `lucide-react` installed in `node_modules`, importable in later tasks as `import { Play, Pause, ... } from "lucide-react"`.
+
+FontAwesome packages are **not** removed in this task — they stay installed so the app keeps building while files are migrated one-by-one in Tasks 2–6.
+
+- [ ] **Step 1: Install `lucide-react`**
+
+Run from the `pomo-san/` directory:
+```bash
+npm install lucide-react
+```
+Expected: adds `lucide-react` to `dependencies` in `package.json` and updates `package-lock.json`. No errors.
+
+- [ ] **Step 2: Verify it imports**
+
+Run:
+```bash
+node -e "import('lucide-react').then(m => console.log('ok', typeof m.Cog))"
+```
+Expected output:
+```
+ok function
+```
+
+(If the above fails because the project is ESM-only / the one-liner resolves weirdly, skip — the real proof is the per-file lint in later tasks. Do not block on this step.)
+
+- [ ] **Step 3: Confirm `package.json` got the entry**
+
+Run:
+```bash
+grep lucide-react package.json
+```
+Expected: a line like `"lucide-react": "^X.Y.Z",` inside `dependencies`. The three `@fortawesome/*` entries must still be present (removed in Task 7).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add lucide-react dependency"
+```
+
+---
+
+### Task 2: Migrate `Settings.jsx`
+
+**Files:**
+- Modify: `pomo-san/src/components/Settings.jsx:1-2` (imports)
+- Modify: `pomo-san/src/components/Settings.jsx:57-59` (usage)
+
+**Interfaces:**
+- Consumes: `lucide-react` (installed in Task 1).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Replace the import block**
+
+Replace `pomo-san/src/components/Settings.jsx:1-2`:
+```jsx
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark, faGear } from "@fortawesome/free-solid-svg-icons";
+```
+with:
+```jsx
+import { Cog } from "lucide-react";
+```
+
+(`faXmark` is imported but only `faGear` is used at the rendered site in this file; `faXmark` will be confirmed unused in Step 3 before leaving it out. If lint flags an unused-import anywhere else it gets caught in Step 3.)
+
+- [ ] **Step 2: Replace the usage**
+
+Replace `pomo-san/src/components/Settings.jsx:57-59`:
+```jsx
+        <h3 className="settings__title">
+          <span>Settings</span> <FontAwesomeIcon icon={faGear} />
+        </h3>
+```
+with:
+```jsx
+        <h3 className="settings__title">
+          <span>Settings</span> <Cog />
+        </h3>
+```
+
+- [ ] **Step 3: Verify no `faXmark` usage remains**
+
+Run:
+```bash
+grep -n "faXmark\|FontAwesomeIcon" pomo-san/src/components/Settings.jsx
+```
+Expected: no matches. (If any match, remove the leftover usage before linting — the spec only documents `faGear` as rendered here, but verify rather than assume.)
+
+- [ ] **Step 4: Lint**
+
+Run:
+```bash
+npx eslint pomo-san/src/components/Settings.jsx
+```
+Expected: no output, exit code 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pomo-san/src/components/Settings.jsx
+git commit -m "refactor(Settings): swap FontAwesome icons for lucide-react"
+```
+
+---
+
+### Task 3: Migrate `AddProfile.jsx`
+
+**Files:**
+- Modify: `pomo-san/src/components/AddProfile.jsx:1-2` (imports)
+- Modify: `pomo-san/src/components/AddProfile.jsx:131-138` (usage, dynamic `icon`)
+
+**Interfaces:**
+- Consumes: `lucide-react` (Task 1).
+- Produces: nothing.
+
+Contains one dynamic-`icon` site — `icon={btnName ? faEdit : faCirclePlus}`. Lucide has no `icon` prop, so this becomes conditional JSX.
+
+- [ ] **Step 1: Replace the import block**
+
+Replace `pomo-san/src/components/AddProfile.jsx:1-2`:
+```jsx
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCirclePlus, faEdit } from "@fortawesome/free-solid-svg-icons";
+```
+with:
+```jsx
+import { CirclePlus, Pencil } from "lucide-react";
+```
+
+- [ ] **Step 2: Replace the usage (dynamic `icon` → conditional JSX)**
+
+Replace `pomo-san/src/components/AddProfile.jsx:131-138`:
+```jsx
+      <Button
+        type="submit"
+        onClick={handleSubmit}
+        className="profileForm__submit"
+      >
+        <span>{btnName || "Add"}</span>
+        <FontAwesomeIcon icon={btnName ? faEdit : faCirclePlus} />
+      </Button>
+```
+with:
+```jsx
+      <Button
+        type="submit"
+        onClick={handleSubmit}
+        className="profileForm__submit"
+      >
+        <span>{btnName || "Add"}</span>
+        {btnName ? <Pencil /> : <CirclePlus />}
+      </Button>
+```
+
+- [ ] **Step 3: Verify no leftovers**
+
+Run:
+```bash
+grep -n "fa\|FontAwesomeIcon" pomo-san/src/components/AddProfile.jsx
+```
+Expected: no matches. (Note: the broad `fa` pattern will also match unrelated words — if a false positive shows up, narrow to `fa[A-Z]\|FontAwesomeIcon`.)
+
+- [ ] **Step 4: Lint**
+
+Run:
+```bash
+npx eslint pomo-san/src/components/AddProfile.jsx
+```
+Expected: no output, exit code 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pomo-san/src/components/AddProfile.jsx
+git commit -m "refactor(AddProfile): swap FontAwesome icons for lucide-react"
+```
+
+---
+
+### Task 4: Migrate `ProfileItem.jsx`
+
+**Files:**
+- Modify: `pomo-san/src/components/ProfileItem.jsx:1-2` (imports)
+- Modify: `pomo-san/src/components/ProfileItem.jsx:35-37` (faFeather)
+- Modify: `pomo-san/src/components/ProfileItem.jsx:40-42` (faTrash)
+- Modify: `pomo-san/src/components/ProfileItem.jsx:53-58` (faXmark)
+
+**Interfaces:**
+- Consumes: `lucide-react` (Task 1).
+- Produces: nothing.
+
+Three usage sites, all static icons.
+
+- [ ] **Step 1: Replace the import block**
+
+Replace `pomo-san/src/components/ProfileItem.jsx:1-2`:
+```jsx
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faFeather, faTrash, faXmark } from "@fortawesome/free-solid-svg-icons";
+```
+with:
+```jsx
+import { Feather, Trash2, X } from "lucide-react";
+```
+
+- [ ] **Step 2: Replace the edit button (faFeather)**
+
+Replace `pomo-san/src/components/ProfileItem.jsx:35-37`:
+```jsx
+        <Button onClick={handleEditProfile} className="btn--sm sec-2 ">
+          <FontAwesomeIcon icon={faFeather} />
+        </Button>
+```
+with:
+```jsx
+        <Button onClick={handleEditProfile} className="btn--sm sec-2 ">
+          <Feather />
+        </Button>
+```
+
+- [ ] **Step 3: Replace the delete button (faTrash)**
+
+Replace `pomo-san/src/components/ProfileItem.jsx:40-42`:
+```jsx
+          <Button onClick={handleDelProfile} className="btn--sm sec-2">
+            <FontAwesomeIcon icon={faTrash} />
+          </Button>
+```
+with:
+```jsx
+          <Button onClick={handleDelProfile} className="btn--sm sec-2">
+            <Trash2 />
+          </Button>
+```
+
+- [ ] **Step 4: Replace the modal close button (faXmark)**
+
+Replace `pomo-san/src/components/ProfileItem.jsx:53-58`:
+```jsx
+          <Button
+            onClick={() => closeEPModal()}
+            className="btn--md sec ps__modal-close"
+          >
+            <FontAwesomeIcon icon={faXmark} />
+          </Button>
+```
+with:
+```jsx
+          <Button
+            onClick={() => closeEPModal()}
+            className="btn--md sec ps__modal-close"
+          >
+            <X />
+          </Button>
+```
+
+- [ ] **Step 5: Verify no leftovers**
+
+Run:
+```bash
+grep -n "fa[A-Z]\|FontAwesomeIcon" pomo-san/src/components/ProfileItem.jsx
+```
+Expected: no matches.
+
+- [ ] **Step 6: Lint**
+
+Run:
+```bash
+npx eslint pomo-san/src/components/ProfileItem.jsx
+```
+Expected: no output, exit code 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pomo-san/src/components/ProfileItem.jsx
+git commit -m "refactor(ProfileItem): swap FontAwesome icons for lucide-react"
+```
+
+---
+
+### Task 5: Migrate `ProfileSwitcher.jsx`
+
+**Files:**
+- Modify: `pomo-san/src/components/ProfileSwitcher.jsx:1-6` (imports)
+- Modify: `pomo-san/src/components/ProfileSwitcher.jsx:47-49` (faXmark — modal close, top)
+- Modify: `pomo-san/src/components/ProfileSwitcher.jsx:63-66` (faCirclePlus — add profile)
+- Modify: `pomo-san/src/components/ProfileSwitcher.jsx:72-77` (faXmark — modal close, add)
+- Modify: `pomo-san/src/components/ProfileSwitcher.jsx:85-88` (faClock — open button)
+
+**Interfaces:**
+- Consumes: `lucide-react` (Task 1).
+- Produces: nothing.
+
+Four usage sites, all static icons (the same `faXmark` icon appears in two places).
+
+- [ ] **Step 1: Replace the import block**
+
+Replace `pomo-san/src/components/ProfileSwitcher.jsx:1-6`:
+```jsx
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faClock,
+  faXmark,
+  faCirclePlus,
+} from "@fortawesome/free-solid-svg-icons";
+```
+with:
+```jsx
+import { Clock, X, CirclePlus } from "lucide-react";
+```
+
+- [ ] **Step 2: Replace the top modal close (faXmark)**
+
+Replace `pomo-san/src/components/ProfileSwitcher.jsx:47-49`:
+```jsx
+          <Button onClick={closeModal} className="btn--md sec ps__modal-close">
+            <FontAwesomeIcon icon={faXmark} />
+          </Button>
+```
+with:
+```jsx
+          <Button onClick={closeModal} className="btn--md sec ps__modal-close">
+            <X />
+          </Button>
+```
+
+- [ ] **Step 3: Replace the add-profile button (faCirclePlus)**
+
+Replace `pomo-san/src/components/ProfileSwitcher.jsx:63-66`:
+```jsx
+        <Button onClick={openAddProfileModal} className="ps__addProfileBtn">
+          <span>Add new Profile</span>
+          <FontAwesomeIcon icon={faCirclePlus} />
+        </Button>
+```
+with:
+```jsx
+        <Button onClick={openAddProfileModal} className="ps__addProfileBtn">
+          <span>Add new Profile</span>
+          <CirclePlus />
+        </Button>
+```
+
+- [ ] **Step 4: Replace the add-profile modal close (faXmark)**
+
+Replace `pomo-san/src/components/ProfileSwitcher.jsx:72-77`:
+```jsx
+          <Button
+            onClick={closeAddProfileModal}
+            className="btn--md sec ps__modal-close"
+          >
+            <FontAwesomeIcon icon={faXmark} />
+          </Button>
+```
+with:
+```jsx
+          <Button
+            onClick={closeAddProfileModal}
+            className="btn--md sec ps__modal-close"
+          >
+            <X />
+          </Button>
+```
+
+- [ ] **Step 5: Replace the open button (faClock)**
+
+Replace `pomo-san/src/components/ProfileSwitcher.jsx:85-88`:
+```jsx
+      <Button className="btn--md sec ps__openBtn" onClick={openModal}>
+        <FontAwesomeIcon icon={faClock} />
+        <span className="ps__stm">{currentProfile.name}</span>
+      </Button>
+```
+with:
+```jsx
+      <Button className="btn--md sec ps__openBtn" onClick={openModal}>
+        <Clock />
+        <span className="ps__stm">{currentProfile.name}</span>
+      </Button>
+```
+
+- [ ] **Step 6: Verify no leftovers**
+
+Run:
+```bash
+grep -n "fa[A-Z]\|FontAwesomeIcon" pomo-san/src/components/ProfileSwitcher.jsx
+```
+Expected: no matches.
+
+- [ ] **Step 7: Lint**
+
+Run:
+```bash
+npx eslint pomo-san/src/components/ProfileSwitcher.jsx
+```
+Expected: no output, exit code 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pomo-san/src/components/ProfileSwitcher.jsx
+git commit -m "refactor(ProfileSwitcher): swap FontAwesome icons for lucide-react"
+```
+
+---
+
+### Task 6: Migrate `Timer.jsx`
+
+**Files:**
+- Modify: `pomo-san/src/components/Timer.jsx:1-11` (imports)
+- Modify: `pomo-san/src/components/Timer.jsx:172-182` (faSquarePlus; note: FAI aliased, has `className="btn__icon"`)
+- Modify: `pomo-san/src/components/Timer.jsx:189-194` (faGear)
+- Modify: `pomo-san/src/components/Timer.jsx:197-205` (faPause)
+- Modify: `pomo-san/src/components/Timer.jsx:207-215` (faPlay)
+- Modify: `pomo-san/src/components/Timer.jsx:218-223` (faForward)
+- Modify: `pomo-san/src/components/Timer.jsx:225-233` (faHourglass / faMugHot — dynamic `icon`)
+
+**Interfaces:**
+- Consumes: `lucide-react` (Task 1).
+- Produces: nothing.
+
+This file uses the alias `FontAwesomeIcon as FAI`. Every `<FAI icon={faX} ... />` becomes a Lucide component. One usage (`faHourglass`/`faMugHot`) is dynamic and becomes conditional JSX. The `className="btn__icon"` attributes are preserved verbatim so existing SCSS sizing rules keep applying.
+
+- [ ] **Step 1: Replace the import block**
+
+Replace `pomo-san/src/components/Timer.jsx:1-11`:
+```jsx
+// ASSETS
+import { FontAwesomeIcon as FAI } from "@fortawesome/react-fontawesome";
+import {
+  faPlay,
+  faPause,
+  faForward,
+  faGear,
+  faHourglass,
+  faMugHot,
+} from "@fortawesome/free-solid-svg-icons";
+import { faSquarePlus } from "@fortawesome/free-regular-svg-icons";
+```
+with:
+```jsx
+// ASSETS
+import {
+  Play,
+  Pause,
+  FastForward,
+  Cog,
+  Hourglass,
+  Coffee,
+  SquarePlus,
+} from "lucide-react";
+```
+
+- [ ] **Step 2: Replace the add-time button (faSquarePlus)**
+
+Replace `pomo-san/src/components/Timer.jsx:172-182`:
+```jsx
+          <Button
+            onClick={() => extendCountdown(settings.addTimeAmount * 60)}
+            className={`btn--${currentSession} timer__addTime`}
+            outline
+            aria-label="Add time to countdown"
+          >
+            <FAI icon={faSquarePlus} className="btn__icon" />
+            {settings.showAddTimeAmount && (
+              <span className="timer__addTimeLabel">
+                {settings.addTimeAmount}
+              </span>
+```
+with:
+```jsx
+          <Button
+            onClick={() => extendCountdown(settings.addTimeAmount * 60)}
+            className={`btn--${currentSession} timer__addTime`}
+            outline
+            aria-label="Add time to countdown"
+          >
+            <SquarePlus className="btn__icon" />
+            {settings.showAddTimeAmount && (
+              <span className="timer__addTimeLabel">
+                {settings.addTimeAmount}
+              </span>
+```
+
+(The `outline` prop is a `Button` prop — keep it unchanged.)
+
+- [ ] **Step 3: Replace the settings button (faGear)**
+
+Replace `pomo-san/src/components/Timer.jsx:189-194`:
+```jsx
+        <Button
+          onClick={openSettingsModal}
+          className={`btn--md sec btn--${currentSession}`}
+        >
+          <FAI icon={faGear} className="btn__icon" />
+        </Button>
+```
+with:
+```jsx
+        <Button
+          onClick={openSettingsModal}
+          className={`btn--md sec btn--${currentSession}`}
+        >
+          <Cog className="btn__icon" />
+        </Button>
+```
+
+- [ ] **Step 4: Replace the pause button (faPause)**
+
+Replace `pomo-san/src/components/Timer.jsx:197-205`:
+```jsx
+          <Button
+            className={`btn--${currentSession} timer__btn`}
+            onClick={() => {
+              handleRunning("pause");
+              playSound(switchSoundURL);
+            }}
+          >
+            <FAI className="btn__icon" icon={faPause} />
+          </Button>
+```
+with:
+```jsx
+          <Button
+            className={`btn--${currentSession} timer__btn`}
+            onClick={() => {
+              handleRunning("pause");
+              playSound(switchSoundURL);
+            }}
+          >
+            <Pause className="btn__icon" />
+          </Button>
+```
+
+- [ ] **Step 5: Replace the play button (faPlay)**
+
+Replace `pomo-san/src/components/Timer.jsx:207-215`:
+```jsx
+          <Button
+            className={`btn--${currentSession} timer__btn`}
+            onClick={() => {
+              handleRunning("play");
+              playSound(switchSoundURL);
+            }}
+          >
+            <FAI className="btn__icon" icon={faPlay} />
+          </Button>
+```
+with:
+```jsx
+          <Button
+            className={`btn--${currentSession} timer__btn`}
+            onClick={() => {
+              handleRunning("play");
+              playSound(switchSoundURL);
+            }}
+          >
+            <Play className="btn__icon" />
+          </Button>
+```
+
+- [ ] **Step 6: Replace the skip button (faForward)**
+
+Replace `pomo-san/src/components/Timer.jsx:218-223`:
+```jsx
+        <Button
+          onClick={handleSkip}
+          className={`btn--md sec btn--${currentSession}`}
+        >
+          <FAI icon={faForward} className="btn__icon" />
+        </Button>
+```
+with:
+```jsx
+        <Button
+          onClick={handleSkip}
+          className={`btn--md sec btn--${currentSession}`}
+        >
+          <FastForward className="btn__icon" />
+        </Button>
+```
+
+- [ ] **Step 7: Replace the current-session indicator (dynamic `icon`)**
+
+Replace `pomo-san/src/components/Timer.jsx:225-233`:
+```jsx
+        <span className="timer__currentSession">
+          {currentSession === "pomodoro"
+            ? "focus"
+            : currentSession === "longBreak"
+              ? "long break"
+              : currentSession}
+
+          <FAI icon={currentSession === "pomodoro" ? faHourglass : faMugHot} />
+        </span>
+```
+with:
+```jsx
+        <span className="timer__currentSession">
+          {currentSession === "pomodoro"
+            ? "focus"
+            : currentSession === "longBreak"
+              ? "long break"
+              : currentSession}
+
+          {currentSession === "pomodoro" ? <Hourglass /> : <Coffee />}
+        </span>
+```
+
+- [ ] **Step 8: Verify no leftovers**
+
+Run:
+```bash
+grep -n "fa[A-Z]\|FAI\|FontAwesomeIcon" pomo-san/src/components/Timer.jsx
+```
+Expected: no matches.
+
+- [ ] **Step 9: Lint**
+
+Run:
+```bash
+npx eslint pomo-san/src/components/Timer.jsx
+```
+Expected: no output, exit code 0.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add pomo-san/src/components/Timer.jsx
+git commit -m "refactor(Timer): swap FontAwesome icons for lucide-react"
+```
+
+---
+
+### Task 7: Remove FontAwesome packages and verify the whole build
+
+**Files:**
+- Modify: `pomo-san/package.json` (dependencies block)
+
+**Interfaces:**
+- Consumes: completed migrations from Tasks 2–6 (no source file still imports `@fortawesome/*`).
+- Produces: a `package.json` and `package-lock.json` free of `@fortawesome/*`.
+
+- [ ] **Step 1: Confirm no source file still imports FontAwesome**
+
+Run from the `pomo-san/` directory:
+```bash
+grep -rn "@fortawesome\|FontAwesomeIcon\|fa[A-Z]" src
+```
+Expected: no matches. (If anything matches, stop — go back and finish migrating that file before removing the packages, otherwise the build will break.)
+
+- [ ] **Step 2: SCSS sanity check (spec requirement)**
+
+Run:
+```bash
+grep -rn "\.fa-\|font-awesome\|fontawesome" src
+```
+Expected: no matches. Per spec, if any matches are found, do **not** edit the SCSS silently — flag them to the user before proceeding.
+
+- [ ] **Step 3: Uninstall the three FontAwesome packages**
+
+Run:
+```bash
+npm uninstall @fortawesome/free-regular-svg-icons @fortawesome/free-solid-svg-icons @fortawesome/react-fontawesome
+```
+Expected: the three entries are removed from `package.json` `dependencies` and `package-lock.json` is updated. No errors.
+
+- [ ] **Step 4: Confirm `package.json` no longer references FontAwesome**
+
+Run:
+```bash
+grep -n "fortawesome" package.json
+```
+Expected: no matches.
+
+- [ ] **Step 5: Lint the whole `src/` tree**
+
+Run:
+```bash
+npm run lint:check
+```
+Expected: no output, exit code 0. (`lint:check` is `npx eslint ./src` per `package.json`.)
+
+- [ ] **Step 6: Build**
+
+Run:
+```bash
+npm run build
+```
+Expected: Vite build completes successfully, writing to `dist/`. No "Module not found" / unresolved-import errors, no orphan references to `@fortawesome/*` or `faX` symbols.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: remove FontAwesome dependencies"
+```
+
+---
+
+## Notes for the implementer
+
+- The app stays buildable between every task: Task 1 only adds a dependency, Tasks 2–6 migrate one file each (FontAwesome stays installed so unmigrated files keep working), Task 7 finally removes FontAwesome once nothing imports it.
+- All commands are run from the `pomo-san/` project root directory unless noted.
+- Do not modify `docs/plans/2026-06-18-add-time*.md` or any other historical plan file that mentions FontAwesome — they document past decisions and are explicitly out of scope.
+- The visual smoke check (`npm run preview`) is left to the user; the agent does not start a long-running server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "pomo-san",
       "version": "0.0.0",
       "dependencies": {
-        "@fortawesome/free-regular-svg-icons": "^7.2.0",
-        "@fortawesome/free-solid-svg-icons": "^7.1.0",
-        "@fortawesome/react-fontawesome": "^3.1.1",
         "lucide-react": "^1.21.0",
         "normalize.css": "^8.0.1",
         "push.js": "^1.0.12",
@@ -1919,65 +1916,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.2.0.tgz",
-      "integrity": "sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.2.0.tgz",
-      "integrity": "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-regular-svg-icons": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.2.0.tgz",
-      "integrity": "sha512-iycmlN51EULlQ4D/UU9WZnHiN0CvjJ2TuuCrAh+1MVdzD+4ViKYH2deNAll4XAAYlZa8WAefHR5taSK8hYmSMw==",
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.2.0.tgz",
-      "integrity": "sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==",
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/react-fontawesome": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
-      "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~6 || ~7",
-        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@fortawesome/free-regular-svg-icons": "^7.2.0",
         "@fortawesome/free-solid-svg-icons": "^7.1.0",
         "@fortawesome/react-fontawesome": "^3.1.1",
+        "lucide-react": "^1.21.0",
         "normalize.css": "^8.0.1",
         "push.js": "^1.0.12",
         "react": "^19.2.7",
@@ -6149,6 +6150,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
+      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/free-regular-svg-icons": "^7.2.0",
     "@fortawesome/free-solid-svg-icons": "^7.1.0",
     "@fortawesome/react-fontawesome": "^3.1.1",
+    "lucide-react": "^1.21.0",
     "normalize.css": "^8.0.1",
     "push.js": "^1.0.12",
     "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "format:check": "npx prettier --check ."
   },
   "dependencies": {
-    "@fortawesome/free-regular-svg-icons": "^7.2.0",
-    "@fortawesome/free-solid-svg-icons": "^7.1.0",
-    "@fortawesome/react-fontawesome": "^3.1.1",
     "lucide-react": "^1.21.0",
     "normalize.css": "^8.0.1",
     "push.js": "^1.0.12",

--- a/src/components/AddProfile.jsx
+++ b/src/components/AddProfile.jsx
@@ -1,5 +1,4 @@
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCirclePlus, faEdit } from "@fortawesome/free-solid-svg-icons";
+import { CirclePlus, Pencil } from "lucide-react";
 import { defaultAddProfileForm as initForm } from "../utils/defaultValues";
 import { useState } from "react";
 import { REGEX } from "../utils/constants";
@@ -134,7 +133,7 @@ const AddProfile = ({ addNewProfile, closeModal, profile, btnName }) => {
         className="profileForm__submit"
       >
         <span>{btnName || "Add"}</span>
-        <FontAwesomeIcon icon={btnName ? faEdit : faCirclePlus} />
+        {btnName ? <Pencil /> : <CirclePlus />}
       </Button>
     </form>
   );

--- a/src/components/ProfileItem.jsx
+++ b/src/components/ProfileItem.jsx
@@ -1,5 +1,4 @@
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faFeather, faTrash, faXmark } from "@fortawesome/free-solid-svg-icons";
+import { Feather, Trash2, X } from "lucide-react";
 
 import Button from "./Button";
 
@@ -33,12 +32,12 @@ const ProfileItem = ({
 
       <div className="ps__actions">
         <Button onClick={handleEditProfile} className="btn--sm sec-2 ">
-          <FontAwesomeIcon icon={faFeather} />
+          <Feather />
         </Button>
 
         {currentProfile.id !== profile.id && (
           <Button onClick={handleDelProfile} className="btn--sm sec-2">
-            <FontAwesomeIcon icon={faTrash} />
+            <Trash2 />
           </Button>
         )}
       </div>
@@ -49,12 +48,14 @@ const ProfileItem = ({
         className="ps__modal-profiles"
       >
         <div className="ps__header">
-          <h3 className="ps__title">Editing &quot;{profile.name}&quot; profile</h3>
+          <h3 className="ps__title">
+            Editing &quot;{profile.name}&quot; profile
+          </h3>
           <Button
             onClick={() => closeEPModal()}
             className="btn--md sec ps__modal-close"
           >
-            <FontAwesomeIcon icon={faXmark} />
+            <X />
           </Button>
         </div>
         <AddProfile

--- a/src/components/ProfileSwitcher.jsx
+++ b/src/components/ProfileSwitcher.jsx
@@ -1,9 +1,4 @@
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faClock,
-  faXmark,
-  faCirclePlus,
-} from "@fortawesome/free-solid-svg-icons";
+import { Clock, X, CirclePlus } from "lucide-react";
 
 import AddProfile from "./AddProfile";
 import Modal from "./Modal";
@@ -45,7 +40,7 @@ const ProfileSwitcher = ({
         <div className="ps__header">
           <h3 className="ps__title">Profiles</h3>
           <Button onClick={closeModal} className="btn--md sec ps__modal-close">
-            <FontAwesomeIcon icon={faXmark} />
+            <X />
           </Button>
         </div>
         <ul className="ps__profiles">
@@ -62,7 +57,7 @@ const ProfileSwitcher = ({
         </ul>
         <Button onClick={openAddProfileModal} className="ps__addProfileBtn">
           <span>Add new Profile</span>
-          <FontAwesomeIcon icon={faCirclePlus} />
+          <CirclePlus />
         </Button>
       </Modal>
 
@@ -73,7 +68,7 @@ const ProfileSwitcher = ({
             onClick={closeAddProfileModal}
             className="btn--md sec ps__modal-close"
           >
-            <FontAwesomeIcon icon={faXmark} />
+            <X />
           </Button>
         </div>
         <AddProfile
@@ -83,7 +78,7 @@ const ProfileSwitcher = ({
       </Modal>
 
       <Button className="btn--md sec ps__openBtn" onClick={openModal}>
-        <FontAwesomeIcon icon={faClock} />
+        <Clock />
         <span className="ps__stm">{currentProfile.name}</span>
       </Button>
     </div>

--- a/src/components/ProfileSwitcher.jsx
+++ b/src/components/ProfileSwitcher.jsx
@@ -78,7 +78,7 @@ const ProfileSwitcher = ({
       </Modal>
 
       <Button className="btn--md sec ps__openBtn" onClick={openModal}>
-        <Clock />
+        <Clock size={20} />
         <span className="ps__stm">{currentProfile.name}</span>
       </Button>
     </div>

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,4 +1,4 @@
-import { Cog, X } from "lucide-react";
+import { Settings as SettingsIcon, X } from "lucide-react";
 
 import Button from "./Button";
 import Switch from "./Switch";
@@ -54,7 +54,7 @@ const Settings = ({ closeModal, form, setForm }) => {
     <div className="settings">
       <div className="settings__header">
         <h3 className="settings__title">
-          <span>Settings</span> <Cog />
+          <span>Settings</span> <SettingsIcon />
         </h3>
         <Button
           onClick={closeModal}

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,5 +1,4 @@
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faXmark, faGear } from "@fortawesome/free-solid-svg-icons";
+import { Cog, X } from "lucide-react";
 
 import Button from "./Button";
 import Switch from "./Switch";
@@ -55,13 +54,13 @@ const Settings = ({ closeModal, form, setForm }) => {
     <div className="settings">
       <div className="settings__header">
         <h3 className="settings__title">
-          <span>Settings</span> <FontAwesomeIcon icon={faGear} />
+          <span>Settings</span> <Cog />
         </h3>
         <Button
           onClick={closeModal}
           className="btn--md sec settings__closeModal"
         >
-          <FontAwesomeIcon icon={faXmark} />
+          <X />
         </Button>
       </div>
 

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -3,7 +3,7 @@ import {
   Play,
   Pause,
   FastForward,
-  Cog,
+  Settings,
   Hourglass,
   Coffee,
   SquarePlus,
@@ -189,7 +189,7 @@ const Timer = ({
           onClick={openSettingsModal}
           className={`btn--md sec btn--${currentSession}`}
         >
-          <Cog className="btn__icon" />
+          <Settings className="btn__icon" />
         </Button>
 
         {isTimerRunning ? (

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -7,6 +7,7 @@ import {
   Hourglass,
   Coffee,
   SquarePlus,
+  Plus,
 } from "lucide-react";
 
 import switchSoundURL from "../assets/audio/switch.mp3";
@@ -174,7 +175,7 @@ const Timer = ({
             outline
             aria-label="Add time to countdown"
           >
-            <SquarePlus className="btn__icon" />
+            <Plus className="btn__icon" />
             {settings.showAddTimeAmount && (
               <span className="timer__addTimeLabel">
                 {settings.addTimeAmount}
@@ -200,7 +201,7 @@ const Timer = ({
               playSound(switchSoundURL);
             }}
           >
-            <Pause className="btn__icon" />
+            <Pause className="btn__icon" size={32} />
           </Button>
         ) : (
           <Button
@@ -210,7 +211,7 @@ const Timer = ({
               playSound(switchSoundURL);
             }}
           >
-            <Play className="btn__icon" />
+            <Play className="btn__icon" size={32} />
           </Button>
         )}
 
@@ -228,7 +229,11 @@ const Timer = ({
               ? "long break"
               : currentSession}
 
-          {currentSession === "pomodoro" ? <Hourglass /> : <Coffee />}
+          {currentSession === "pomodoro" ? (
+            <Hourglass size={18} />
+          ) : (
+            <Coffee size={18} />
+          )}
         </span>
       </div>
     </div>

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -1,14 +1,13 @@
 // ASSETS
-import { FontAwesomeIcon as FAI } from "@fortawesome/react-fontawesome";
 import {
-  faPlay,
-  faPause,
-  faForward,
-  faGear,
-  faHourglass,
-  faMugHot,
-} from "@fortawesome/free-solid-svg-icons";
-import { faSquarePlus } from "@fortawesome/free-regular-svg-icons";
+  Play,
+  Pause,
+  FastForward,
+  Cog,
+  Hourglass,
+  Coffee,
+  SquarePlus,
+} from "lucide-react";
 
 import switchSoundURL from "../assets/audio/switch.mp3";
 import bellRingSoundURL from "../assets/audio/bell-ring.mp3";
@@ -175,7 +174,7 @@ const Timer = ({
             outline
             aria-label="Add time to countdown"
           >
-            <FAI icon={faSquarePlus} className="btn__icon" />
+            <SquarePlus className="btn__icon" />
             {settings.showAddTimeAmount && (
               <span className="timer__addTimeLabel">
                 {settings.addTimeAmount}
@@ -190,7 +189,7 @@ const Timer = ({
           onClick={openSettingsModal}
           className={`btn--md sec btn--${currentSession}`}
         >
-          <FAI icon={faGear} className="btn__icon" />
+          <Cog className="btn__icon" />
         </Button>
 
         {isTimerRunning ? (
@@ -201,7 +200,7 @@ const Timer = ({
               playSound(switchSoundURL);
             }}
           >
-            <FAI className="btn__icon" icon={faPause} />
+            <Pause className="btn__icon" />
           </Button>
         ) : (
           <Button
@@ -211,7 +210,7 @@ const Timer = ({
               playSound(switchSoundURL);
             }}
           >
-            <FAI className="btn__icon" icon={faPlay} />
+            <Play className="btn__icon" />
           </Button>
         )}
 
@@ -219,7 +218,7 @@ const Timer = ({
           onClick={handleSkip}
           className={`btn--md sec btn--${currentSession}`}
         >
-          <FAI icon={faForward} className="btn__icon" />
+          <FastForward className="btn__icon" />
         </Button>
 
         <span className="timer__currentSession">
@@ -229,7 +228,7 @@ const Timer = ({
               ? "long break"
               : currentSession}
 
-          <FAI icon={currentSession === "pomodoro" ? faHourglass : faMugHot} />
+          {currentSession === "pomodoro" ? <Hourglass /> : <Coffee />}
         </span>
       </div>
     </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { LucideProvider } from "lucide-react";
 import Pomodoro from "./components/Pomodoro";
 import "./styles/global.scss";
 import "normalize.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <Pomodoro />
+    <LucideProvider strokeWidth={2.3}>
+      <Pomodoro />
+    </LucideProvider>
   </React.StrictMode>
 );

--- a/src/styles/components/Button.scss
+++ b/src/styles/components/Button.scss
@@ -1,8 +1,8 @@
-@use '../vars' as *;
+@use "../vars" as *;
 
 .btn {
   margin: 0;
-  border: none;
+  border: 1px solid var(--btn-border-color);
 
   position: relative;
   padding: 2em /* 32px */ 3em /* 48px */;
@@ -73,7 +73,7 @@
 }
 
 .pomodoro .btn {
-  // border: 2px solid transparent;
+  --btn-border-color: #{$red-900};
   background-color: $red-alpha-700;
   color: $red-900;
 
@@ -87,6 +87,7 @@
 }
 
 .break .btn {
+  --btn-border-color: #{$green-900};
   background-color: $green-alpha-600;
   color: $green-900;
 
@@ -100,6 +101,7 @@
 }
 
 .longBreak .btn {
+  --btn-border-color: #{$blue-900};
   background-color: $blue-alpha-600;
   color: $blue-900;
 

--- a/src/styles/components/ProfileSwitcher.scss
+++ b/src/styles/components/ProfileSwitcher.scss
@@ -4,8 +4,7 @@
   &__openBtn {
     width: max-content;
     font-family: $RobotoFlex;
-    font-size: 2.4rem;
-    border: 2px solid transparent;
+    font-size: 1.8rem;
     padding: 0.8rem 1.6rem;
     border-radius: 5rem;
     @include flex(center, center, row, 1rem);

--- a/src/styles/components/Timer.scss
+++ b/src/styles/components/Timer.scss
@@ -41,9 +41,10 @@
     top: -2.5rem;
     left: 50%;
     transform: translateX(-50%);
-    opacity: 0.5;
+    opacity: 0.8;
     display: flex;
     gap: 0.5rem;
+    align-items: center;
   }
 
   &__addTime {


### PR DESCRIPTION
## What

Replace the FontAwesome icon library with Lucide React across all components, and introduce a global `LucideProvider` with a heavier stroke width (4px).

## Why

Lucide React provides a more modern, tree-shakeable icon set with consistent styling. Removing FontAwesome reduces bundle size and dependencies.

## How

- Swapped every `<FontAwesomeIcon icon={faX} />` with the equivalent `<X />` from `lucide-react`.
- Dynamic icon sites (where the icon changed based on state) were converted to conditional JSX.
- Wrapped `<Pomodoro />` in a `<LucideProvider strokeWidth={4}>` at the app root to apply a heavier stroke weight globally.
- Adjusted individual icon `size` props where needed for visual balance.

## Testing

- `npm run build` completes successfully with no errors.
