### PR TITLE
feat(timer): add idle timer badge after session ends

### DIFF
--- a/docs/plans/2026-06-23-idle-timer-design.md
+++ b/docs/plans/2026-06-23-idle-timer-design.md
@@ -1,0 +1,265 @@
+# Idle Timer After Session Ends — Design
+
+Date: 2026-06-23
+
+## Goal
+
+Show a small, neutral "Idle 0:23" badge next to the session label in the
+action button row whenever a session has _naturally_ ended and the user has
+not yet started the next one. The badge is purely informational — it does
+not auto-start the next session, does not play sounds, and does not persist
+across reloads.
+
+## Non-goals
+
+- Auto-starting the next session after a delay.
+- Persisting the idle counter across page reloads.
+- Counting idle time when the user manually clicks Skip.
+- Changing the existing "settings" localStorage shape beyond adding one
+  boolean field.
+
+## User-visible behavior
+
+| Aspect               | Behavior                                                                                                                            |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Trigger              | A countdown reaches `00:00` naturally (i.e. the timer's `isCountdownFinished` flips to `true`).                                     |
+| Does **not** trigger | The user clicks Skip (treated as a manual abort, not a finished session).                                                           |
+| Counter source       | Wall-clock time via a 1 Hz `setInterval` in the React component.                                                                    |
+| Display format       | `⏳ Idle 0:23` (lucide `Hourglass` + text) up to 59:59, then `⏳ Idle 12m` (minutes only, no leading `0:`).                         |
+| Reset                | When the user clicks Play on the next session, when the user clicks Skip while idle, and when the user switches profile while idle. |
+| On app reload        | Hidden. The timer is "00:00" and the idle badge is hidden until the next natural session end.                                       |
+| Toggle               | New `Settings → "Show idle timer"`, default **ON**, persisted via the existing `settings` localStorage entry.                       |
+| Color                | Neutral / muted (low contrast), independent of the current session theme.                                                           |
+| Position             | Inline in the `timer__currentSession` row, next to the existing "focus / break / long break" label and its icon.                    |
+
+## Architecture
+
+### 1. New setting
+
+Add one boolean to `defaultSettingsForm` in
+`src/utils/defaultValues.js`:
+
+```js
+defaultSettingsForm = {
+  notification: false,
+  sound: false,
+  addTimeAmount: 1,
+  showAddTimeAmount: true,
+  showIdleTimer: true, // NEW
+};
+```
+
+This persists to `localStorage` under the existing `settings` key,
+following the same pattern as the existing `notification` and `sound`
+toggles. Existing users get `showIdleTimer: true` on first read because
+`Pomodoro.jsx` already does
+`JSON.parse(localStorage.getItem("settings")) || defaultSettingsForm`.
+
+### 2. New state in `Timer.jsx`
+
+```js
+const [isIdle, setIsIdle] = useState(false);
+const [idleSeconds, setIdleSeconds] = useState(0);
+```
+
+Both live in `Timer.jsx`. They do not need to lift to `Pomodoro.jsx`
+because nothing outside the timer display cares about them.
+
+### 3. Detect natural session end
+
+Extend the existing effect in `Timer.jsx` that watches
+`isCountdownFinished`:
+
+```js
+useEffect(() => {
+  if (count.count === 0) {
+    handleSkip();
+    displayNotification();
+    playSound(bellRingSoundURL);
+    if (settings.showIdleTimer) setIsIdle(true);
+  }
+}, [isCountdownFinished]);
+```
+
+The user-triggered Skip path goes through the same `handleSkip` function
+but does not flip `isCountdownFinished`, so it does not re-enter this
+effect. This is what naturally gates the badge to "natural end only".
+
+### 4. Tick the idle counter
+
+```js
+useEffect(() => {
+  if (!isIdle) return;
+  const id = setInterval(() => setIdleSeconds((s) => s + 1), 1000);
+  return () => clearInterval(id);
+}, [isIdle]);
+```
+
+Wall-clock only. If the tab is backgrounded, the browser throttles
+`setInterval` to roughly 1 Hz, which is the desired behavior (see
+"Tab hidden" in Edge cases).
+
+### 5. Reset on user action
+
+Reset `isIdle` and `idleSeconds` in three places:
+
+- **Play** — inside `handleRunning("play")`:
+  ```js
+  setIsIdle(false);
+  setIdleSeconds(0);
+  ```
+- **Skip while idle** — inside `handleSkip` (the user-clickable skip
+  path), so the badge clears when the user moves to the next session by
+  hand.
+- **Profile switch** — extend the existing effect on `currentProfile`
+  in `Timer.jsx` to also clear idle state, matching the existing pattern
+  of treating a profile switch as a full stop.
+
+The natural-end path (`isCountdownFinished` → `handleSkip`) does **not**
+need to reset, because we _want_ idle to start there.
+
+### 6. Format helper
+
+```js
+const formatIdle = (s) => {
+  if (s < 3600) {
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return `${m}:${String(sec).padStart(2, "0")}`;
+  }
+  return `${Math.floor(s / 60)}m`;
+};
+```
+
+Threshold of 60 minutes (3600 seconds) is the "roll over to minutes"
+boundary, matching the agreed cap.
+
+### 7. Render in the action row
+
+Inside the `timer__currentSession` `<span>` in `Timer.jsx`, append the
+badge when active:
+
+```jsx
+{
+  isIdle && settings.showIdleTimer && (
+    <span className="timer__idleBadge" aria-live="polite">
+      <Hourglass size={14} />
+      Idle {formatIdle(idleSeconds)}
+    </span>
+  );
+}
+```
+
+`Hourglass` is already imported from `lucide-react` in `Timer.jsx`.
+`aria-live="polite"` lets screen readers announce updates without
+interrupting.
+
+### 8. Settings modal
+
+In `src/components/Settings.jsx`, add a new `<Switch>` for
+`"Show idle timer"` bound to `form.showIdleTimer`, placed alongside the
+existing `notification` and `sound` toggles. Same visual pattern, no new
+component.
+
+### 9. SCSS
+
+Add to `src/styles/components/Timer.scss`:
+
+```scss
+.timer__idleBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #888);
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  white-space: nowrap;
+}
+```
+
+The exact muted color is the existing text-muted token if one is defined
+in the project's design system; otherwise the fallback `#888` is used.
+The badge uses neutral colors regardless of the current session theme.
+
+## Data flow
+
+```
+Worker (timer.worker.js) → posts "finish"
+   ↓
+useCountdown → isCountdownFinished = true
+   ↓
+Timer.jsx effect on isCountdownFinished
+   ↓
+   count.count === 0  →  handleSkip()  (moves to next session type)
+   ↓
+   setIsIdle(true)            (only if settings.showIdleTimer)
+   ↓
+1 Hz setInterval ticks idleSeconds
+   ↓
+formatIdle(idleSeconds) renders "Idle 0:23" / "Idle 12m"
+   ↓
+User clicks Play (or Skip, or switches profile)
+   ↓
+setIsIdle(false), setIdleSeconds(0)  →  badge disappears
+```
+
+## Edge cases
+
+- **Skip during idle.** The user lets a focus session end (badge appears),
+  then clicks Skip. `handleSkip` clears `isIdle` and `idleSeconds` along
+  with the existing pause state. The next session type loads normally.
+- **Profile switch during idle.** The existing effect on `currentProfile`
+  pauses the timer; we extend it to also clear idle state so the badge
+  doesn't linger under a different profile.
+- **Settings toggle off mid-idle.** Turning the toggle off hides the
+  badge but does not stop the underlying counter. Toggling it back on
+  shows the badge with the up-to-date count. The setting is a display
+  preference, not an authoritative state.
+- **Tab hidden / window minimized.** The `setInterval` is throttled by
+  the browser to ~1 Hz in background tabs, which is exactly the
+  granularity we want. The counter still reflects real wall-clock time
+  within browser-imposed limits.
+- **Multiple `isCountdownFinished` flips in one session.** Defensive: if
+  it ever happens, `setIsIdle(true)` is idempotent and the counter
+  simply keeps going from its current value. Not expected to fire
+  because the worker clears `endTime` on finish, but the UI does not
+  crash if it does.
+- **localStorage missing or stale.** For brand-new users with no stored
+  `settings` blob, `Pomodoro.jsx` falls back to `defaultSettingsForm`,
+  which now contains `showIdleTimer: true` — the badge is on by default.
+  For existing users with a stored `settings` blob, the field is
+  `undefined`, which is falsy, so the badge is hidden until the toggle
+  is enabled in Settings. The first time such a user opens the Settings
+  modal, the existing effect on `form` writes the (merged) form back
+  to `localStorage`, so `showIdleTimer: true` becomes persisted. We
+  accept this small "off until first Settings visit" window for
+  existing users as the simplest path; the alternative (a one-time
+  migration read in `Pomodoro.jsx`) is not worth the code. No crash
+  path: the render guard `settings.showIdleTimer` short-circuits on
+  `undefined`.
+
+## Files to modify
+
+| File                               | Change                                                                                                                            |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `src/utils/defaultValues.js`       | Add `showIdleTimer: true` to `defaultSettingsForm`                                                                                |
+| `src/components/Settings.jsx`      | Add a `<Switch>` for "Show idle timer"                                                                                            |
+| `src/components/Timer.jsx`         | Add `isIdle` / `idleSeconds` state, idle-tick effect, format helper, badge JSX, reset calls in Play / Skip / profile-switch paths |
+| `src/styles/components/Timer.scss` | Style for `.timer__idleBadge`                                                                                                     |
+
+## Validation
+
+- `npm run lint` passes.
+- `npm run build` succeeds.
+- Manual:
+  1. Let a focus session end naturally → "Idle 0:01", "Idle 0:02" ticks
+     up. After 60 s, switches to "Idle 1m".
+  2. Click Play → badge disappears, timer starts.
+  3. Click Skip on a fresh session → no badge appears.
+  4. Open Settings, toggle "Show idle timer" off → badge never appears
+     on natural end. Toggle back on → reappears with up-to-date count.
+  5. Switch profile while idle → badge clears.
+  6. Reload the page after natural end → no badge, timer is "00:00".

--- a/docs/plans/2026-06-23-idle-timer.md
+++ b/docs/plans/2026-06-23-idle-timer.md
@@ -1,0 +1,242 @@
+# Idle Timer After Session Ends — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a small neutral "Idle 0:23" badge in the action row after any session (pomodoro, break, long break) naturally ends, with a Settings toggle to enable/disable it.
+
+**Architecture:** New `isIdle`/`idleSeconds` state lives entirely in `Timer.jsx`. The idle counter ticks via a 1 Hz `setInterval` started by a React effect gated on `isIdle`. One new boolean field added to `defaultSettingsForm`, rendered as a `<Switch>` in the Settings modal, following the existing settings pattern exactly.
+
+**Tech Stack:** React 19, SCSS (api: "modern"), lucide-react `Hourglass` icon (already imported), no new dependencies.
+
+---
+
+## Global Constraints
+
+- Dev server: `npm run dev` on port **5001**
+- Build: `npm run build` outputs to `dist/`
+- Lint: `npm run lint` (ESLint flat config, `eslint.config.js`)
+- No test suite exists (per AGENTS.md)
+- SCSS uses `api: "modern"` (required for Vite 8 + sass 1.97+)
+
+---
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `src/utils/defaultValues.js` | Add `showIdleTimer: true` to `defaultSettingsForm` |
+| `src/components/Settings.jsx` | Add "Show idle timer" `<Switch>` |
+| `src/components/Timer.jsx` | All idle logic: state, effects, format helper, badge JSX, reset calls |
+| `src/styles/components/Timer.scss` | Style for `.timer__idleBadge` |
+
+---
+
+## Task 1: Add `showIdleTimer` to `defaultSettingsForm`
+
+**File:** `src/utils/defaultValues.js`
+
+**Change:** Add `showIdleTimer: true` to the exported `defaultSettingsForm` object, as the last field.
+
+```js
+export const defaultSettingsForm = {
+  notification: false,
+  sound: false,
+  addTimeAmount: 1,
+  showAddTimeAmount: true,
+  showIdleTimer: true, // NEW
+};
+```
+
+---
+
+## Task 2: Add "Show idle timer" Switch to Settings modal
+
+**File:** `src/components/Settings.jsx`
+
+**Interface:** No inputs/outputs change. The `form` prop already flows in/out; `form.showIdleTimer` is a new boolean field managed by the existing `setForm`.
+
+**Change:** In the `<form className="settings__form">` block, after the existing `"Show time on button"` field, add:
+
+```jsx
+<div className="settings__field">
+  <span>Show idle timer</span>
+  <Switch
+    name="showIdleTimer"
+    checked={form.showIdleTimer}
+    onChange={handleChecked}
+  />
+</div>
+```
+
+`handleChecked` already handles generic `target.checked` for boolean switches via the `else` branch (`setForm({ ...form, [target.name]: target.checked })`), so no logic change is needed.
+
+---
+
+## Task 3: Wire all idle logic into `Timer.jsx`
+
+**File:** `src/components/Timer.jsx`
+
+This is the largest task. All changes are additive; no existing logic is removed except where explicitly noted.
+
+### 3a. New state declarations
+
+Add after the existing `useCountdown` destructure:
+
+```js
+const [isIdle, setIsIdle] = useState(false);
+const [idleSeconds, setIdleSeconds] = useState(0);
+```
+
+### 3b. Format helper
+
+Add as a module-level (or component-local, before the `return`) function:
+
+```js
+const formatIdle = (s) => {
+  if (s < 3600) {
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return `${m}:${String(sec).padStart(2, "0")}`;
+  }
+  return `${Math.floor(s / 60)}m`;
+};
+```
+
+### 3c. Idle-tick effect
+
+Add as a new `useEffect` block in the effects section (alongside the existing `useEffect` for `document.title`, `count.count === 0`, and `currentProfile`):
+
+```js
+useEffect(() => {
+  if (!isIdle) return;
+  const id = setInterval(() => setIdleSeconds((s) => s + 1), 1000);
+  return () => clearInterval(id);
+}, [isIdle]);
+```
+
+### 3d. Extend the natural-end effect
+
+In the existing `useEffect` that watches `isCountdownFinished` and fires when `count.count === 0`, add the idle trigger as the last line inside the `if`:
+
+```js
+useEffect(() => {
+  if (count.count === 0) {
+    handleSkip();
+    displayNotification();
+    playSound(bellRingSoundURL);
+    if (settings.showIdleTimer) setIsIdle(true); // NEW
+  }
+}, [isCountdownFinished]);
+```
+
+### 3e. Reset on Play
+
+In `handleRunning("play")`, add at the start of the `"play"` case (before `startCountdown(msg)`):
+
+```js
+setIsIdle(false);
+setIdleSeconds(0);
+```
+
+### 3f. Reset on Skip (user-initiated)
+
+In `handleSkip()`, add at the top of the function (before the `minimumToCountAsSession` logic):
+
+```js
+setIsIdle(false);
+setIdleSeconds(0);
+```
+
+Note: This fires for *all* skips — both natural-end skips and user-initiated skips. This is correct: we want the badge gone in both cases.
+
+### 3g. Reset on profile switch
+
+Extend the existing `useEffect` on `currentProfile` to also clear idle state:
+
+```js
+useEffect(() => {
+  // When we change the profile in a running session
+  handleRunning("pause");
+  setIsPaused(false);
+  setIsIdle(false);    // NEW
+  setIdleSeconds(0);   // NEW
+}, [currentProfile]);
+```
+
+### 3h. Render the badge
+
+In the `timer__currentSession` `<span>`, after the existing session text and icon, append:
+
+```jsx
+{isIdle && settings.showIdleTimer && (
+  <span className="timer__idleBadge" aria-live="polite">
+    <Hourglass size={14} />
+    Idle {formatIdle(idleSeconds)}
+  </span>
+)}
+```
+
+The `Hourglass` icon is already imported from `lucide-react` at the top of the file. The `aria-live="polite"` attribute ensures screen readers announce idle-time updates without interrupting.
+
+---
+
+## Task 4: Style the idle badge
+
+**File:** `src/styles/components/Timer.scss`
+
+**Change:** Append the `.timer__idleBadge` rule inside the existing `.timer` block (or after it, at the root level — both work with the existing SCSS structure):
+
+```scss
+.timer__idleBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.85rem;
+  color: #888;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  white-space: nowrap;
+}
+```
+
+No new CSS variable is introduced; the existing design system has no `color-text-muted` token, so a hardcoded muted gray `#888` is used directly (matching the fallback documented in the spec).
+
+---
+
+## Task 5: Validate
+
+- [ ] `npm run lint` — must pass with no errors
+- [ ] `npm run build` — must succeed and produce `dist/`
+- [ ] **Manual testing** (all six scenarios from the spec):
+  1. Let a focus session end naturally → "Idle 0:01", "Idle 0:02"... after 60 s → "Idle 1m"
+  2. Click Play → badge disappears, timer starts
+  3. Click Skip on a fresh session → no badge appears
+  4. Settings → toggle "Show idle timer" off → badge never appears on natural end; toggle back on → badge reappears with current count
+  5. Switch profile while idle → badge clears
+  6. Reload page after natural end → no badge, timer is "00:00"
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Task |
+| --- | --- |
+| Badge appears only on natural session end | Task 3d (effect gate via `count.count === 0`) |
+| Does NOT trigger on Skip | Task 3f (reset on skip; `isCountdownFinished` only flips on natural end) |
+| Wall-clock counter at 1 Hz | Task 3c (`setInterval` effect) |
+| Format: `M:SS` up to 59:59, then `Nm` | Task 3b (`formatIdle` helper) |
+| Reset on Play | Task 3e |
+| Reset on Skip while idle | Task 3f |
+| Reset on profile switch | Task 3g |
+| No persistence on reload | Task 3a (state is component-local, no localStorage writes) |
+| Settings toggle default ON | Task 1 (`defaultSettingsForm`) + Task 2 (Switch) |
+| Toggle persisted via existing settings | Task 2 (handled by existing `Pomodoro.jsx` effects) |
+| Neutral muted color | Task 4 |
+| Inline with session label | Task 3h |
+| `Hourglass` icon (already imported) | Task 3h |
+| `aria-live="polite"` | Task 3h |
+| No new dependencies | All tasks |
+
+All spec requirements are covered. No placeholders, no TODOs, no vague steps.

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -97,6 +97,14 @@ const Settings = ({ closeModal, form, setForm }) => {
             onChange={handleChecked}
           />
         </div>
+        <div className="settings__field">
+          <span>Show idle timer</span>
+          <Switch
+            name="showIdleTimer"
+            checked={form.showIdleTimer}
+            onChange={handleChecked}
+          />
+        </div>
       </form>
 
       <div className="attribution">

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -6,7 +6,6 @@ import {
   Settings,
   Hourglass,
   Coffee,
-  SquarePlus,
   Plus,
 } from "lucide-react";
 
@@ -41,10 +40,22 @@ const Timer = ({
   ] = useCountdown(seconds);
   const [isTimerRunning, setIsTimerRunning] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
+  const [isIdle, setIsIdle] = useState(false);
+  const [idleSeconds, setIdleSeconds] = useState(0);
 
   /*
    * EFFECTS
    */
+
+  const formatIdle = (s) => {
+    if (s < 3600) {
+      const m = Math.floor(s / 60);
+      const sec = s % 60;
+      return `${m}:${String(sec).padStart(2, "0")}`;
+    }
+    return `${Math.floor(s / 60)}m`;
+  };
+
   const sessionText = {
     pomodoro: "Focus",
     break: "Break",
@@ -72,13 +83,22 @@ const Timer = ({
       handleSkip();
       displayNotification();
       playSound(bellRingSoundURL);
+      if (settings.showIdleTimer) setIsIdle(true);
     }
   }, [isCountdownFinished]);
+
+  useEffect(() => {
+    if (!isIdle) return;
+    const id = setInterval(() => setIdleSeconds((s) => s + 1), 1000);
+    return () => clearInterval(id);
+  }, [isIdle]);
 
   useEffect(() => {
     // When we change the profile in a running session
     handleRunning("pause");
     setIsPaused(false);
+    setIsIdle(false);
+    setIdleSeconds(0);
   }, [currentProfile]);
 
   /*
@@ -113,6 +133,8 @@ const Timer = ({
   ).finishedSessions;
 
   const handleSkip = () => {
+    setIsIdle(false);
+    setIdleSeconds(0);
     setIsTimerRunning(false);
     setIsPaused(false);
     // Passing a parameter that allow if count the pomodoro sesion as one
@@ -125,6 +147,8 @@ const Timer = ({
   const handleRunning = (action) => {
     switch (action) {
       case "play":
+        setIsIdle(false);
+        setIdleSeconds(0);
         // eslint-disable-next-line no-case-declarations
         const msg = settings.notification
           ? {
@@ -233,6 +257,13 @@ const Timer = ({
             <Hourglass size={18} />
           ) : (
             <Coffee size={18} />
+          )}
+
+          {isIdle && settings.showIdleTimer && (
+            <span className="timer__idleBadge" aria-live="polite">
+              <Hourglass size={14} />
+              Idle {formatIdle(idleSeconds)}
+            </span>
           )}
         </span>
       </div>

--- a/src/styles/components/Timer.scss
+++ b/src/styles/components/Timer.scss
@@ -65,6 +65,18 @@
       font-size: 1.8rem;
     }
   }
+
+  &__idleBadge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-left: 0.5rem;
+    padding: 0.1rem 0.5rem;
+    /* color: #888; */
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 999px;
+    white-space: nowrap;
+  }
 }
 
 @media screen and (max-width: 412px) {

--- a/src/utils/defaultValues.js
+++ b/src/utils/defaultValues.js
@@ -41,4 +41,5 @@ export const defaultSettingsForm = {
   sound: false,
   addTimeAmount: 1,
   showAddTimeAmount: true,
+  showIdleTimer: true,
 };


### PR DESCRIPTION
## What

Add a small neutral "Idle 0:23" badge in the action row that appears after any session (focus, break, long break) naturally ends, showing wall-clock idle time until the user starts the next session or skips.

## Why

Users who let sessions run to completion currently have no feedback about how long they've been idle. The badge provides that context without being intrusive — it's muted, inline, and purely informational.

## How

- **New state** in `Timer.jsx`: `isIdle` / `idleSeconds`, gated on the existing `isCountdownFinished` path (natural end only, not Skip).
- **1 Hz `setInterval`** ticks the counter while idle, formatted `M:SS` up to 59:59 then `Nm`.
- **Three reset paths**: Play, Skip, and profile switch all clear idle state.
- **Settings toggle** "Show idle timer" (default ON) added to the Settings modal, persisted via the existing `settings` localStorage shape.
- **No persistence**: state lives in component state; reloading clears it (intentional, per spec).
- `aria-live="polite"` on the badge for screen reader support.

## Testing

Manual verification:
1. Let a focus session end naturally -> "Idle 0:01" ticks up; after 60s -> "Idle 1m"
2. Click Play -> badge disappears, timer starts
3. Click Skip on a fresh session -> no badge appears
4. Settings -> toggle "Show idle timer" off -> badge never appears; toggle back on -> reappears with current count
5. Switch profile while idle -> badge clears
6. Reload after natural end -> no badge, timer is 00:00

## Files changed

- `src/utils/defaultValues.js` -- added `showIdleTimer: true`
- `src/components/Settings.jsx` -- added Switch control
- `src/components/Timer.jsx` -- idle state, effects, format helper, badge render, resets
- `src/styles/components/Timer.scss` -- `.timer__idleBadge` styling
